### PR TITLE
Optional requirement for bitshuffle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ scipy
 networkx >= 2.0
 h5py
 peewee >= 3.10
-bitshuffle @ git+https://github.com/kiyo-masui/bitshuffle.git
 caput @ git+https://github.com/radiocosmology/caput.git
 skyfield >= 1.10
 mpi4py

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     extras_require={
         "chimedb_config": [
             "chimedb.config @ git+ssh://git@github.com/chime-experiment/chimedb_config.git"
+        ],
+        "bitshuffle": [
+            "bitshuffle @ git+https://github.com/kiyo-masui/bitshuffle.git"
         ]
     },
     package_data=ch_util_data,


### PR DESCRIPTION
Bitshuffle has problems with python >=3.7 and it is not needed by many funtionalities of ch_util. In fact, we do not use it in CHIME/FRB baseband analysis. I edited the setup to have bitshuffle as an extra requirement