### PR TITLE
fix(finder): Rename StorageNode.mounted to StorageNode.active

### DIFF
--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -253,7 +253,7 @@ class Finder(object):
             for n in (
                 di.StorageNode.select()
                 .where(di.StorageNode.host == host)
-                .where(di.StorageNode.mounted)
+                .where(di.StorageNode.active)
             ):
                 self._my_node.append(n)
         else:


### PR DESCRIPTION
This code block should rarely, if ever, be used.  It's only helpful
in the rare case that you're running `Finder` on a host that also
happens to be running `alpenhornd`.