### PR TITLE
doc(layout): Encourage use of username with set_user

### DIFF
--- a/ch_util/_db_tables.py
+++ b/ch_util/_db_tables.py
@@ -227,7 +227,9 @@ def _check_user(perm):
             raise NoPermission("You do not have the permissions to %s." % p.long_name)
         except pw.DoesNotExist:
             raise RuntimeError(
-                "Internal error: {} is missing from the loaded permissions".format(perm)
+                "Internal error: _check_user called with unknown permission: {}".format(
+                    perm
+                )
             )
 
 

--- a/ch_util/_db_tables.py
+++ b/ch_util/_db_tables.py
@@ -172,7 +172,11 @@ def set_user(u):
     Parameters
     ----------
     u : string or integer
-      Your user identifier: the integer id, the username, or the full name.
+      One of:
+        - your CHIMEwiki username (string).  Use an initial capital letter.
+          This is the recommended input.
+        - the name entered into the "real name" field in your CHIMEwiki profile
+        - your CHIMEwiki integer user_id (not easy to find)
 
     Raises
     ------
@@ -222,7 +226,7 @@ def _check_user(perm):
             )
             raise NoPermission("You do not have the permissions to %s." % p.long_name)
         except pw.DoesNotExist:
-            raise RuntimeError("Wow, code is broken.")
+            raise RuntimeError("Internal error: {} is missing from the loaded permissions".format(perm))
 
 
 def _peewee_get_current_user():

--- a/ch_util/_db_tables.py
+++ b/ch_util/_db_tables.py
@@ -226,7 +226,9 @@ def _check_user(perm):
             )
             raise NoPermission("You do not have the permissions to %s." % p.long_name)
         except pw.DoesNotExist:
-            raise RuntimeError("Internal error: {} is missing from the loaded permissions".format(perm))
+            raise RuntimeError(
+                "Internal error: {} is missing from the loaded permissions".format(perm)
+            )
 
 
 def _peewee_get_current_user():

--- a/ch_util/layout.py
+++ b/ch_util/layout.py
@@ -30,11 +30,12 @@ For most uses, you probably want to import the following:
 
 If you will be altering the layouts, you will need to register as a user:
 
->>> layout.set_user("Adam Hincks")
+>>> layout.set_user("Ahincks")
 
-Your user account is shared with the CHIME wiki. Note that different users have
-different permissions, stored in the :class:`user_permission` table. If you are
-simply reading from the layout, there is no need to register as a user.
+Use your CHIME wiki username here.  Make sure it starts with a capital letter.
+Note that different users have different permissions, stored in the
+:class:`user_permission` table. If you are simply reading from the layout,
+there is no need to register as a user.
 
 Choose Your Own Adventure
 =========================


### PR DESCRIPTION
The previous layout docuemntation implied you needed to pass your "real name" (whatever that is) when calling `set_user`.
This is problematic for a few reasons:
- it confuses the notion of someone's actual name and the value of the CHIMEwiki `user_real_name` field (which is what's being matched here)
- the `user_real_name` field is typically populated by sysadmins when creating a wiki account.  It's available and can be changed by users in the wiki profile page, but most wiki users don't change it nor do they even know what the value has been set to.
- There's absolutely no validation performed on the column.  I've seen misspelled names, blank names, email addresses in this column.
- There's no requirement that the values of `user_real_name` be unique.

This changes the docs to encourage using CHIMEwiki usernames when calling `set_user`.  Usernames are much better to use because:
- they're guaranteed to be unique
- they're unambiguous in form, meaning simple string matching is a reasonable thing to do.
- they're well known to users, since users use them to log into the wiki

Note: this doesn't change any functionality: users are still able to pass the value of the `user_real_name` field associated
with their account to this function.

(Bonus reading: [Personal names are never a good thing to key a database on for multiple reasons](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/))