### PR TITLE
fix(requirements): Bump peewee requirement to 3.14.1 or newer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy >= 1.16
 scipy
 networkx >= 2.0
 h5py
-peewee >= 3.10
+peewee >= 3.14.1
 bitshuffle
 caput[compression] @ git+https://github.com/radiocosmology/caput.git
 skyfield >= 1.10


### PR DESCRIPTION
When using a `layout.Component` instance to look up a `layout.Connexion` we appear to have been affected by  https://github.com/coleifer/peewee/issues/2304 which was fixed in Peewee 3.14.1.

This was most noticeable when using `from_pair(comp1, comp2)`.

This bug is also the reason we had to make this fix: https://github.com/chime-experiment/ch_util_private/pull/34 (which didn't make any sense to me at the time)

Peewee-2 was not affected by this bug, which is why this code worked when we originally created the layout API.