### PR TITLE
feat(tools): Support querying correlator inputs for CHIME/FRB Outriggers

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -441,6 +441,30 @@ class CHIMEAntenna(ArrayAntenna):
     _delay = 0  # Treat CHIME antennas as defining the delay zero point
 
 
+class AllenbyAntenna(ArrayAntenna):
+    """Allenby outrigger antenna for the CHIME/FRB project."""
+    
+    _rotation = 0.00
+    _offset = [0.00, 0.00, 0.00]
+    _delay = 0
+
+
+class GBOAntenna(ArrayAntenna):
+    """GBO outrigger antenna for the CHIME/FRB project."""
+
+    _rotation = 0.00
+    _offset = [0.00, 0.00, 0.00]
+    _delay = 0
+
+
+class HCROAntenna(ArrayAntenna):
+    """HCRO outrigger antenna for the CHIME/FRB project."""
+
+    _rotation = 0.00
+    _offset = [0.00, 0.00, 0.00]
+    _delay = 0
+
+
 class TONEAntenna(ArrayAntenna):
     """Antenna that is part of GBO/TONE Outrigger.
     Let's allow for a global rotation and offset.
@@ -515,7 +539,7 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
     # Check if the correlator input component contains a chan_id property
     corr_prop = lay.node_property(corr_input)
     chan_id = int(corr_prop["chan_id"].value) if "chan_id" in corr_prop else None
-
+    
     rfl = None
     cas = None
     slt = None
@@ -615,12 +639,15 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
         "cylinder_B": 3,
         "cylinder_C": 4,
         "cylinder_D": 5,
+        "allenby_cylinder": 6,
+        "gbo_cylinder": 7,
+        "hcro_cylinder": 8,
     }
 
     cyl = pos_dict[rfl.sn]
 
     # Different conventions for CHIME and Pathfinder
-    if cyl >= 2:
+    if (cyl >= 2 and cyl <= 5):
 
         # Dealing with a CHIME feed
 
@@ -657,7 +684,7 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             flag=flag,
         )
 
-    else:
+    elif (cyl == 0 or cyl == 1):
 
         # Dealing with a pathfinder feed
 
@@ -709,6 +736,70 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             powered=pwd,
             flag=flag,
         )
+    
+    elif (cyl == 6):
+
+        # Dealing with an Allenby feed
+        
+        # Temporary setting until this is defined
+        pos = None
+        
+        # Return AllenbyAntenna object
+        return AllenbyAntenna(
+            id=chan_id,
+            input_sn=corr_input.sn,
+            corr=corr_sn,
+            reflector=rfl.sn,
+            cyl=cyl,
+            pos=pos,
+            pol=pdir,
+            antenna=ant.sn,
+            rf_thru=rft_sn,
+            flag=flag,
+        )
+    
+    elif (cyl == 7):
+
+        # Dealing with a GBO feed
+
+        # Temporary setting until this is defined
+        pos = None
+
+        # Return GBOAntenna object
+        return GBOAntenna(
+            id=chan_id,
+            input_sn=corr_input.sn,
+            corr=corr_sn,
+            reflector=rfl.sn,
+            cyl=cyl,
+            pos=pos,
+            pol=pdir,
+            antenna=ant.sn,
+            rf_thru=rft_sn,
+            flag=flag,
+        )
+    
+    elif (cyl == 8):
+
+        # Dealing with a HCRO feed
+
+        # Temporary setting until this is defined
+        pos = None
+
+        # Return HCROAntenna object
+        return HCROAntenna(
+            id=chan_id,
+            input_sn=corr_input.sn,
+            corr=corr_sn,
+            reflector=rfl.sn,
+            cyl=cyl,
+            pos=pos,
+            pol=pdir,
+            antenna=ant.sn,
+            rf_thru=rft_sn,
+            flag=flag,
+        )
+
 
 
 # Public Functions
@@ -1156,6 +1247,8 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
             correlator = "K7BP16-0004"
         elif correlator.lower() == "chime":
             correlator = "FCC"
+        elif correlator.lower() == "allenby":
+            correlator = "FCA"
         elif correlator.lower() == "tone":
             # A hack to return GBO correlator inputs
             correlator = "tone"
@@ -1219,20 +1312,20 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
     # Perform nearly all the graph queries in one huge batcn to speed things up,
     # and pass the results into _get_input_props for further processing
     corrs = layout_graph.closest_of_type(inputs, "correlator", type_exclude=coax_type)
-
+    
     rfls = layout_graph.shortest_path_to_type(inputs, "reflector", type_exclude=block)
-
+    
     block.append("reflector")
     rfi_ants = layout_graph.closest_of_type(inputs, "RFI antenna", type_exclude=block)
     noise_sources = layout_graph.closest_of_type(
         inputs, "noise source", type_exclude=block
     )
-
+    
     inputlist = [
         _get_input_props(layout_graph, *args)
         for args in zip(inputs, corrs, rfls, rfi_ants, noise_sources)
     ]
-
+    
     # Filter to include only inputs attached to the given correlator. In theory
     # this shouldn't be necessary if the earlier filtering worked, but I think
     # it'll help catch some odd cases
@@ -1241,7 +1334,7 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
 
     # Sort by channel ID
     inputlist.sort(key=lambda input_: input_.id)
-
+    
     return inputlist
 
 

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -441,8 +441,8 @@ class CHIMEAntenna(ArrayAntenna):
     _delay = 0  # Treat CHIME antennas as defining the delay zero point
 
 
-class AllenbyAntenna(ArrayAntenna):
-    """Allenby outrigger antenna for the CHIME/FRB project."""
+class PCOAntenna(ArrayAntenna):
+    """PCO outrigger antenna for the CHIME/FRB project."""
 
     _rotation = 0.00
     _offset = [0.00, 0.00, 0.00]
@@ -639,14 +639,14 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
         "cylinder_B": 3,
         "cylinder_C": 4,
         "cylinder_D": 5,
-        "allenby_cylinder": 6,
+        "pco_cylinder": 6,
         "gbo_cylinder": 7,
         "hcro_cylinder": 8,
     }
 
     cyl = pos_dict[rfl.sn]
 
-    # Different conventions for CHIME and Pathfinder
+    # Different conventions for CHIME, PCO, GBO, HCRO, and Pathfinder
     if cyl >= 2 and cyl <= 5:
 
         # Dealing with a CHIME feed
@@ -739,13 +739,13 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
 
     elif cyl == 6:
 
-        # Dealing with an Allenby feed
+        # Dealing with an PCO feed
 
         # Temporary setting until this is defined
         pos = None
 
-        # Return AllenbyAntenna object
-        return AllenbyAntenna(
+        # Return PCOAntenna object
+        return PCOAntenna(
             id=chan_id,
             input_sn=corr_input.sn,
             corr=corr_sn,
@@ -1246,7 +1246,7 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
             correlator = "K7BP16-0004"
         elif correlator.lower() == "chime":
             correlator = "FCC"
-        elif correlator.lower() == "allenby":
+        elif correlator.lower() == "pco":
             correlator = "FCA"
         elif correlator.lower() == "tone":
             # A hack to return GBO correlator inputs

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -443,7 +443,7 @@ class CHIMEAntenna(ArrayAntenna):
 
 class AllenbyAntenna(ArrayAntenna):
     """Allenby outrigger antenna for the CHIME/FRB project."""
-    
+
     _rotation = 0.00
     _offset = [0.00, 0.00, 0.00]
     _delay = 0
@@ -539,7 +539,7 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
     # Check if the correlator input component contains a chan_id property
     corr_prop = lay.node_property(corr_input)
     chan_id = int(corr_prop["chan_id"].value) if "chan_id" in corr_prop else None
-    
+
     rfl = None
     cas = None
     slt = None
@@ -647,7 +647,7 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
     cyl = pos_dict[rfl.sn]
 
     # Different conventions for CHIME and Pathfinder
-    if (cyl >= 2 and cyl <= 5):
+    if cyl >= 2 and cyl <= 5:
 
         # Dealing with a CHIME feed
 
@@ -684,7 +684,7 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             flag=flag,
         )
 
-    elif (cyl == 0 or cyl == 1):
+    elif cyl == 0 or cyl == 1:
 
         # Dealing with a pathfinder feed
 
@@ -736,14 +736,14 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             powered=pwd,
             flag=flag,
         )
-    
-    elif (cyl == 6):
+
+    elif cyl == 6:
 
         # Dealing with an Allenby feed
-        
+
         # Temporary setting until this is defined
         pos = None
-        
+
         # Return AllenbyAntenna object
         return AllenbyAntenna(
             id=chan_id,
@@ -757,8 +757,8 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             rf_thru=rft_sn,
             flag=flag,
         )
-    
-    elif (cyl == 7):
+
+    elif cyl == 7:
 
         # Dealing with a GBO feed
 
@@ -778,8 +778,8 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             rf_thru=rft_sn,
             flag=flag,
         )
-    
-    elif (cyl == 8):
+
+    elif cyl == 8:
 
         # Dealing with a HCRO feed
 
@@ -799,7 +799,6 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
             rf_thru=rft_sn,
             flag=flag,
         )
-
 
 
 # Public Functions
@@ -1312,20 +1311,20 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
     # Perform nearly all the graph queries in one huge batcn to speed things up,
     # and pass the results into _get_input_props for further processing
     corrs = layout_graph.closest_of_type(inputs, "correlator", type_exclude=coax_type)
-    
+
     rfls = layout_graph.shortest_path_to_type(inputs, "reflector", type_exclude=block)
-    
+
     block.append("reflector")
     rfi_ants = layout_graph.closest_of_type(inputs, "RFI antenna", type_exclude=block)
     noise_sources = layout_graph.closest_of_type(
         inputs, "noise source", type_exclude=block
     )
-    
+
     inputlist = [
         _get_input_props(layout_graph, *args)
         for args in zip(inputs, corrs, rfls, rfi_ants, noise_sources)
     ]
-    
+
     # Filter to include only inputs attached to the given correlator. In theory
     # this shouldn't be necessary if the earlier filtering worked, but I think
     # it'll help catch some odd cases
@@ -1334,7 +1333,7 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
 
     # Sort by channel ID
     inputlist.sort(key=lambda input_: input_.id)
-    
+
     return inputlist
 
 


### PR DESCRIPTION
There was no logic for handling `allenby_cylinder` when using `tools.py --> get_correlator_input(..., correlator="allenby")`.

This introduced the following errors when using `get_correlator_input` to query the correlator inputs for Allenby:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-18-f2cce6172052> in <module>
      1 inputmap = tools.get_correlator_inputs(ephemeris.unix_to_datetime(f['timestamp'][0, 0]['ctime']),
----> 2                                                    correlator=None)

/usr/local/lib/python3.6/site-packages/ch_util/tools.py in get_correlator_inputs(lay_time, correlator, connect)
   1235     inputlist = [
   1236         _get_input_props(layout_graph, *args)
-> 1237         for args in zip(inputs, corrs, rfls, rfi_ants, noise_sources)
   1238     ]
   1239 

/usr/local/lib/python3.6/site-packages/ch_util/tools.py in <listcomp>(.0)
   1235     inputlist = [
   1236         _get_input_props(layout_graph, *args)
-> 1237         for args in zip(inputs, corrs, rfls, rfi_ants, noise_sources)
   1238     ]
   1239 

/usr/local/lib/python3.6/site-packages/ch_util/tools.py in _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
    623     }
    624 
--> 625     cyl = pos_dict[rfl.sn]
    626 
    627     # Different conventions for CHIME and Pathfinder

KeyError: 'allenby_cylinder'
```

This PR implements skeleton classes for the Allenby, GBO, and HCRO telescopes. It also defines the logic for handling this error when the condition on `cyl = pos_dict[rfl.sn]` is evaluated.