### PR TITLE
ss/narrowband-gain-error

### DIFF
--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2095,7 +2095,7 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
 
             # Define kernel
             kernel = ConstantKernel(
-                constant_value=var, constant_value_bounds=(0.1 * var, 100.0 * var)
+                constant_value=var, constant_value_bounds=(0.01 * var, 100.0 * var)
             ) * Matern(length_scale=length_scale, length_scale_bounds="fixed", nu=1.5)
 
             # Regress against non-flagged data

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2112,6 +2112,11 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
             if iscomplex:
                 interp_gain[test, ii] += 1.0j * (ypred[:, 1] + ytrain_mu[:, 1])
 
+            if err_ypred.ndim > 1:
+                err_ypred = np.sqrt(
+                    np.sum(err_ypred**2, axis=-1) / err_ypred.shape[-1]
+                )
+
             interp_weight[test, ii] = tools.invert_no_zero(err_ypred**2)
 
         else:

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2113,10 +2113,19 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
             # Predict error
             ypred, err_ypred = gp.predict(xtest, return_std=True)
 
+            # When the gains are not complex, ypred will have a single dimension for
+            # sklearn version 1.1.2, but will have a second dimension of length 1 for
+            # earlier versions.  The line below ensures consistent behavior.
+            if ypred.ndim == 1:
+                ypred = ypred[:, np.newaxis]
+
             interp_gain[test, ii] = ypred[:, 0] + ytrain_mu[:, 0]
             if iscomplex:
                 interp_gain[test, ii] += 1.0j * (ypred[:, 1] + ytrain_mu[:, 1])
 
+            # When the gains are complex, err_ypred will have a second dimension
+            # of length 2 for sklearn version 1.1.2, but will have a single dimension
+            # for earlier versions.  The line below ensures consistent behavior.
             if err_ypred.ndim > 1:
                 err_ypred = np.sqrt(
                     np.sum(err_ypred**2, axis=-1) / err_ypred.shape[-1]

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2051,6 +2051,8 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
 
     nfreq, ninput = gain.shape
 
+    iscomplex = np.any(np.iscomplex(gain))
+
     interp_gain = gain.copy()
     interp_weight = weight.copy()
 
@@ -2068,9 +2070,13 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
             xtest = x[test, :]
 
             xtrain = x[train, :]
-            ytrain = np.hstack(
-                (gain[train, ii, np.newaxis].real, gain[train, ii, np.newaxis].imag)
-            )
+            if iscomplex:
+                ytrain = np.hstack(
+                    (gain[train, ii, np.newaxis].real, gain[train, ii, np.newaxis].imag)
+                )
+            else:
+                ytrain = gain[train, ii, np.newaxis].real
+
             # Mean subtract
             ytrain_mu = np.mean(ytrain, axis=0, keepdims=True)
             ytrain = ytrain - ytrain_mu
@@ -2086,23 +2092,26 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
                 )
                 ** 2
             )
+
             # Define kernel
-            kernel = ConstantKernel(var) * Matern(
-                length_scale=length_scale, length_scale_bounds="fixed", nu=1.5
-            )
+            kernel = ConstantKernel(
+                constant_value=var, constant_value_bounds=(0.1 * var, 100.0 * var)
+            ) * Matern(length_scale=length_scale, length_scale_bounds="fixed", nu=1.5)
 
             # Regress against non-flagged data
             gp = gaussian_process.GaussianProcessRegressor(
                 kernel=kernel, alpha=alpha[train, ii]
             )
+
             gp.fit(xtrain, ytrain)
 
             # Predict error
             ypred, err_ypred = gp.predict(xtest, return_std=True)
 
-            interp_gain[test, ii] = (ypred[:, 0] + ytrain_mu[:, 0]) + 1.0j * (
-                ypred[:, 1] + ytrain_mu[:, 1]
-            )
+            interp_gain[test, ii] = ypred[:, 0] + ytrain_mu[:, 0]
+            if iscomplex:
+                interp_gain[test, ii] += 1.0j * (ypred[:, 1] + ytrain_mu[:, 1])
+
             interp_weight[test, ii] = tools.invert_no_zero(err_ypred**2)
 
         else:

--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -618,6 +618,9 @@ def highpass_delay_filter(freq, tau_cut, flag, epsilon=1e-10):
     """Construct a high-pass delay filter.
 
     The stop band will range from [-tau_cut, tau_cut].
+    DAYENU is used to construct the filter in the presence
+    of masked frequencies.  See Ewall-Wice et al. 2021
+    (arXiv:2004.11397) for a description.
 
     Parameters
     ----------

--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -740,7 +740,7 @@ def iterative_hpf_masking(
     while itt < niter:
 
         # Construct the filter using the current mask
-        NF, index = highpass_delay_filter(freq, tau_cut, new_flag, epsilon=epsilon)
+        NF = highpass_delay_filter(freq, tau_cut, new_flag, epsilon=epsilon)
 
         # Apply the filter
         yhpf = np.matmul(NF, y)
@@ -771,7 +771,7 @@ def iterative_hpf_masking(
         itt += 1
 
     # Construct and apply the filter using the final flag
-    NF, index = highpass_delay_filter(freq, tau_cut, new_flag, epsilon=epsilon)
+    NF = highpass_delay_filter(freq, tau_cut, new_flag, epsilon=epsilon)
 
     yhpf = np.matmul(NF, y)
 

--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -632,7 +632,7 @@ def highpass_delay_filter(freq, tau_cut, flag, epsilon=1e-10):
 
     Returns
     -------
-    pinv : np.ndarray[ntime_uniq, nfreq, nfreq]
+    pinv : np.ndarray[nfreq, nfreq]
         High pass delay filter.
     """
 


### PR DESCRIPTION
Adds a new method `rfi.iterative_hpf_masking` that implements the algorithm used to identify narrowband features in the gains.  I am putting it in `ch_util` in case we want to use it in the real-time pipeline in the future.

Also makes a few modifications to `cal_utils.interpolate_gain` to make it work with the pipeline used to flag these features.

