### PR TITLE
Parallel RFI filtering

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -2354,5 +2354,12 @@ def invert_no_zero(x):
     r : np.ndarray
         Return the reciprocal of x.
     """
-    with np.errstate(divide="ignore", invalid="ignore"):
-        return np.where(x == 0, 0.0, 1.0 / x)
+    out = np.zeros_like(x)
+    np.divide(
+        np.array(1, dtype=x.dtype),
+        x.view(np.ndarray),
+        out=out.view(np.ndarray),
+        where=x != 0,
+    )
+
+    return out


### PR DESCRIPTION
In its current implementation, the RFI Filter step of the daily pipeline takes ~25 minutes. Most of this time is spent taking a rolling median, and it is done in a single process. This PR should address the issue by pre-calculating a median across frequencies to flatten the auto vis. data, then distributing across the frequency axis to distribute the computation across processes. 