### PR TITLE
feat(finder): add exclude_nighttime method to Finder

### DIFF
--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -1098,6 +1098,17 @@ class Finder(object):
             set_time = ephemeris.solar_setting(rise_time)
             self.exclude_time_interval(rise_time, set_time)
 
+    def exclude_nighttime(self):
+        """Add time intervals to exclude all night time data."""
+
+        set_times = ephemeris.solar_setting(
+            self.time_range[0] - 24 * 3600.0, self.time_range[1]
+        )
+
+        for set_time in set_times:
+            rise_time = ephemeris.solar_rising(set_time)
+            self.exclude_time_interval(set_time, rise_time)
+
     def exclude_sun(self, time_delta=4000.0, time_delta_rise_set=4000.0):
         """Add time intervals to exclude sunrise, sunset, and sun transit.
 


### PR DESCRIPTION
Allows user to retrieve only daytime data for solar analysis.