### PR TITLE
feat(ephemeris): add convert ICRS to beam-model XY

### DIFF
--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -716,7 +716,7 @@ def equat_to_bmxy(ra_icrs, dec_icrs, time):
     bmx, bmy : array_like
         The CHIME/FRB beam model X and Y coordinates in degrees as defined in
         the beam-model coordinate conventions:
-        https://chimefrb.github.io/frb_common/build/html/beam_model.html
+        https://chime-frb-open-data.github.io/beam-model/#coordinate-conventions
     """
 
     from skyfield.api import Star, Angle
@@ -754,7 +754,7 @@ def hadec_to_bmxy(ha_cirs, dec_cirs):
     bmx, bmy : array_like
         The CHIME/FRB beam model X and Y coordinates in degrees as defined in
         the beam-model coordinate conventions:
-        https://chimefrb.github.io/frb_common/build/html/beam_model.html
+        https://chime-frb-open-data.github.io/beam-model/#coordinate-conventions
     """
 
     from caput.interferometry import sph_to_ground

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -721,12 +721,6 @@ def equat_to_bmxy(ra_icrs, dec_icrs, time):
 
     from skyfield.api import Star, Angle
 
-    from caput.interferometry import sph_to_ground
-
-    from ch_util.tools import _CHIME_ROT
-
-    from drift.telescope.cylbeam import rotate_ypr
-
     # Create skyfield Star object from ICRS coordinates
     ra = Angle(degrees=ra_icrs)
     dec = Angle(degrees=dec_icrs)
@@ -738,6 +732,36 @@ def equat_to_bmxy(ra_icrs, dec_icrs, time):
 
     # Compute CIRS Hour Angle
     ha_cirs = unix_to_lsa(time) - ra_cirs
+
+    # Get CHIME/FRB beam model XY position
+    bmx, bmy = hadec_to_bmxy(ha_cirs, dec_cirs)
+
+    return bmx, bmy
+
+
+def hadec_to_bmxy(ha_cirs, dec_cirs):
+    """Convert CIRS hour angle and declination to CHIME/FRB beam-model XY coordinates.
+
+    Parameters
+    ----------
+    ha_cirs : float
+        The CIRS Hour Angle of a position in degrees.
+    dec_cirs : float
+        The CIRS Declination of a position in degrees.
+
+    Returns
+    -------
+    bmx, bmy : array_like
+        The CHIME/FRB beam model X and Y coordinates in degrees as defined in
+        the beam-model coordinate conventions:
+        https://chimefrb.github.io/frb_common/build/html/beam_model.html
+    """
+
+    from caput.interferometry import sph_to_ground
+
+    from ch_util.tools import _CHIME_ROT
+
+    from drift.telescope.cylbeam import rotate_ypr
 
     # Convert CIRS coordinates to CHIME "ground fixed" XYZ coordinates,
     # which constitute a unit vector pointing towards the point of interest,

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -696,49 +696,6 @@ def object_coords(body, date=None, deg=False, obs=chime):
     return ra, dec
 
 
-def equat_to_bmxy(ra_icrs, dec_icrs, time):
-    """Convert ICRS equatorial coordinates to CHIME/FRB beam-model XY coordinates.
-
-    Similar to `beam_model.util.get_position_from_equatorial`, but the results
-    seem to be different by up to ~20 arcsec.
-
-    Parameters
-    ----------
-    ra_icrs : float
-        The ICRS Right Ascension of the source in degrees.
-    dec_icrs : float
-        The ICRS Declination of the source in degrees.
-    time : array_like
-        Unix time.
-
-    Returns
-    -------
-    bmx, bmy : array_like
-        The CHIME/FRB beam model X and Y coordinates in degrees as defined in
-        the beam-model coordinate conventions:
-        https://chime-frb-open-data.github.io/beam-model/#coordinate-conventions
-    """
-
-    from skyfield.api import Star, Angle
-
-    # Create skyfield Star object from ICRS coordinates
-    ra = Angle(degrees=ra_icrs)
-    dec = Angle(degrees=dec_icrs)
-    source = Star(ra=ra, dec=dec)
-
-    # Convert ICRS to CIRS coordinates (by passing a date to object_coords,
-    # it returns CIRS coordinates at that epoch)
-    ra_cirs, dec_cirs = object_coords(source, date=time, deg=True)
-
-    # Compute CIRS Hour Angle
-    ha_cirs = unix_to_lsa(time) - ra_cirs
-
-    # Get CHIME/FRB beam model XY position
-    bmx, bmy = hadec_to_bmxy(ha_cirs, dec_cirs)
-
-    return bmx, bmy
-
-
 def hadec_to_bmxy(ha_cirs, dec_cirs):
     """Convert CIRS hour angle and declination to CHIME/FRB beam-model XY coordinates.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ bitshuffle
 caput[compression] @ git+https://github.com/radiocosmology/caput.git
 skyfield >= 1.10
 mpi4py
+driftscan @ git+https://github.com/radiocosmology/driftscan.git


### PR DESCRIPTION
Add function to convert ICRS equatorial coordinates to CHIME/FRB beam-model XY coordinates

Should do the same as the CHIME/FRB beam-model utility `get_position_from_equatorial`:
https://github.com/CHIMEFRB/beam-model/blob/068e410a99bfb18e469a878e659c26393278874f/beam_model/utils.py#L122