### PR TITLE
Dataset_id (1/2): properly load distributed dataset_id dataset

### DIFF
--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -362,6 +362,11 @@ class CorrData(BaseData):
         return self.flags["inputs"]
 
     @property
+    def dataset_id(self):
+        """Access dataset id dataset in unicode format."""
+        return memh5.ensure_unicode(self.flags["dataset_id"][:])
+
+    @property
     def nprod(self):
         """Length of the prod axis."""
         return len(self.index_map["prod"])

--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -771,6 +771,7 @@ class CorrData(BaseData):
             "gain",
             "gain_coeff",
             "frac_lost",
+            "dataset_id",
             "eval",
             "evec",
             "erms",
@@ -789,8 +790,8 @@ class CorrData(BaseData):
             # If this should be distributed, extract the sections and turn them into an MPIArray
             if name in _DIST_DSETS:
                 array = mpiarray.MPIArray.wrap(old_dset._data, axis=0, comm=comm)
-            # Otherwise just copy copy out the old dataset
             else:
+                # Otherwise just copy out the old dataset
                 array = old_dset[:]
 
             # Create the new dataset and copy over attributes
@@ -806,8 +807,8 @@ class CorrData(BaseData):
             # If this should be distributed, extract the sections and turn them into an MPIArray
             if name in _DIST_DSETS:
                 array = mpiarray.MPIArray.wrap(old_dset._data, axis=0, comm=comm)
-            # Otherwise just copy copy out the old dataset
             else:
+                # Otherwise just copy out the old dataset
                 array = old_dset[:]
 
             # Create the new dataset and copy over attributes

--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -3126,10 +3126,6 @@ def andata_from_archive2(
             dataset.real = data["r"]
             dataset.imag = data["i"]
 
-        # Convert any string types to unicode. At the moment this should only effect
-        # the dataset_id dataset
-        dataset = memh5.ensure_unicode(dataset)
-
         return dataset
 
     # The actual read, file by file.

--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -364,7 +364,10 @@ class CorrData(BaseData):
     @property
     def dataset_id(self):
         """Access dataset id dataset in unicode format."""
-        return memh5.ensure_unicode(self.flags["dataset_id"][:])
+        dsid = memh5.ensure_unicode(self.flags["dataset_id"][:])
+        dsid.flags.writeable = False
+
+        return dsid
 
     @property
     def nprod(self):


### PR DESCRIPTION
This PR adds `dataset_id` to the list of distributed datasets to load in `andata.CorrData`, removes the conversion from bytestring to unicode when loading datasets from file, and adds a property to `andata.CorrData` to access `dataset_id` in unicode.

This is a bit of a workaround since unicode/bytestring conversion isn't handled for distributed datasets in `caput.memh5`. I'll change this eventually.

Accompanies chime-experiment/ch_pipeline#175