### PR TITLE
Doppler shift due to Earth's motion and rotation

### DIFF
--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -954,11 +954,11 @@ def get_range_rate(
     Returns
     -------
     range_rate
-        Rate at which the distance between the observer and source changes
-        (i.e., the velocity of observer in direction of source, but positive
-        for observer and source moving appart). If either `source` or `date`
-        contains multiple entries, `range_rate` will be an array. Otherwise,
-        `range_rate` will be a float.
+        Rate (in m/s) at which the distance between the observer and source
+        changes (i.e., the velocity of observer in direction of source, but
+        positive for observer and source moving appart). If either `source`
+        or `date` contains multiple entries, `range_rate` will be an array.
+        Otherwise, `range_rate` will be a float.
 
     Notes
     -----

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -880,7 +880,7 @@ def get_doppler_shifted_freq(
     Parameters
     ----------
     source
-        Position on the sky. If the input is a `str`, attempt to resolve this
+        Position(s) on the sky. If the input is a `str`, attempt to resolve this
         from `ch_util.hfbcat.HFBCatalog`.
     date
         Unix time(s) for which to calculate Doppler shift.
@@ -895,7 +895,12 @@ def get_doppler_shifted_freq(
     -------
     freq_obs
         Doppler shifted frequencies in MHz. Array where rows correspond to the
-        different input rest frequencies and columns to the input times.
+        different input rest frequencies and columns correspond either to input
+        times or to input sky positions (whichever contains multiple entries).
+
+    Notes
+    -----
+    Only one of `source` and `date` can contain multiple entries.
     """
 
     from scipy.constants import c as speed_of_light
@@ -925,7 +930,7 @@ def get_doppler_shifted_freq(
     freq_rest = np.asarray(_ensure_list(freq_rest))[:, np.newaxis]
 
     # Convert unix times to skyfield times
-    date = unix_to_skyfield_time(_ensure_list(date))
+    date = unix_to_skyfield_time(date)
 
     # Create skyfield Apparent object of source position seen from observer
     position = obs.skyfield_obs().at(date).observe(source).apparent()
@@ -940,7 +945,7 @@ def get_doppler_shifted_freq(
     # Dot product of observer velocity and source position gives observer
     # velocity in direction of source; flip sign to get range rate (positive
     # for observer and source moving appart)
-    range_rate = -np.sum(obs_vel_m_per_s.T * source_pos_norm.T, axis=1)
+    range_rate = -np.sum(obs_vel_m_per_s.T * source_pos_norm.T, axis=-1)
 
     # Compute observed frequencies from rest frequencies
     # using relativistic Doppler effect

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -894,6 +894,18 @@ def get_doppler_shifted_freq(
     Notes
     -----
     Only one of `source` and `date` can contain multiple entries.
+
+    Example
+    -------
+    To get the Doppler shifted frequencies of a feature with a rest frequency
+    of 600 MHz for two positions on the sky at a single point in time (Unix
+    time 1717809534 = 2024-06-07T21:18:54+00:00), run:
+
+    >>> from skyfield.starlib import Star
+    >>> from skyfield.positionlib import Angle
+    >>> from ch_util.tools import get_doppler_shifted_freq
+    >>> coord = Star(ra=Angle(degrees=[100, 110]), dec=Angle(degrees=[45, 50]))
+    >>> get_doppler_shifted_freq(coord, 1717809534, 600)
     """
 
     from scipy.constants import c as speed_of_light

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -867,8 +867,15 @@ def get_doppler_shifted_freq(
     obs: Observer = chime,
 ) -> np.array:
     """Calculate Doppler shifted frequency of spectral feature with rest
-    frequency `freq_rest`, seen towards source `source` at time `date`,
-    due to Earth's motion and rotation.
+    frequency `freq_rest`, seen towards source `source` at time `date`, due to
+    Earth's motion and rotation, following the relativistic Doppler effect.
+
+    Note: This routine uses an :class:`skyfield.positionlib.Apparent` object
+    (rather than an :class:`skyfield.positionlib.Astrometric` object) to find
+    the velocity of the observatory and the position of the source. This
+    accounts for the gravitational deflection and the aberration of light.
+    It is unclear if the latter should be taken into account for this Doppler
+    shift calculation, but its effects are negligible.
 
     Parameters
     ----------

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -905,27 +905,14 @@ def get_doppler_shifted_freq(
 
     # Get rest frequency from HFB catalog
     if freq_rest is None:
-        if not source.names:
+        if not source.names or source.names not in HFBCatalog:
             raise ValueError(
                 "Rest frequencies must be supplied unless source can be found "
                 "in ch_util.hfbcat.HFBCatalog. "
                 f"Got source {source} with names {source.names}"
             )
-        elif source.names not in HFBCatalog:
-            raise KeyError(
-                f"Could not find source {source.names} in HFB catalog."
-                "Please provide rest frequencies."
-            )
         else:
-            freq_abs = HFBCatalog[source.names].freq_abs
-            nfreq_abs = len(freq_abs)
-            if nfreq_abs == 1:
-                freq_rest = freq_abs[0]
-            else:
-                raise NotImplementedError(
-                    f"Source {source.names} has {nfreq_abs} absorption features"
-                    "listed in the catalog. Please manually enter a rest frequency."
-                )
+            freq_rest = HFBCatalog[source.names].freq_abs
 
     # Prepare rest frequencies for broadcasting
     freq_rest = np.asarray(_ensure_list(freq_rest))[:, np.newaxis]

--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -925,12 +925,12 @@ def get_doppler_shifted_freq(
     )
 
     # Get radial velocity of source in frame of obs (positive for moving away)
-    range_rate = position.frame_latlon_and_rates(topos)[5].m_per_s
+    range_rate = -position.frame_latlon_and_rates(topos)[5].m_per_s
 
     # Compute observed frequency from rest frequency
     # using relativistic Doppler effect
     beta = range_rate / speed_of_light
-    freq_obs = freq_rest * np.sqrt((1.0 + beta) / (1.0 - beta))
+    freq_obs = freq_rest * np.sqrt((1.0 - beta) / (1.0 + beta))
 
     return freq_obs
 


### PR DESCRIPTION
This is currently set up as follows:
- You can provide either a position on the sky as a `skyfield.starlib.Star` object or an HFB source name as a string (which will be looked up in the HFB catalog).
- You provide a list of unix times of length `T` and a list of rest frequencies of length `F`, and you get out an array of Doppler shifted frequencies of shape `(F, T)`.
- In case the source is in the HFB catalog, you can omit the rest frequency, in which case the rest frequency of the absorption feature as listed in the catalog will be used.

We could also split it up into a base function for Doppler shifting (to be used in a pipeline task) and a convenience function for quickly getting Doppler shifted frequencies of HFB sources with known absorption feature frequencies.

I'll work on the pipeline task for Doppler shifting and see how that interacts with this, but comments on this are welcome