### PR TITLE
fix: alias name kko to FCA in get_correlator_inputs

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -1369,7 +1369,7 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
             correlator = "FCA"
         elif correlator.lower() == "kko":
             correlator = "FCA"
-        elif correlator.lower() == 'gbo':
+        elif correlator.lower() == "gbo":
             correlator = "FCG"
         elif correlator.lower() == "tone":
             # A hack to return GBO correlator inputs

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -1367,6 +1367,8 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
             correlator = "FCC"
         elif correlator.lower() == "pco":
             correlator = "FCA"
+        elif correlator.lower() == "kko":
+            correlator = "FCA"
         elif correlator.lower() == "tone":
             # A hack to return GBO correlator inputs
             correlator = "tone"

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -1369,6 +1369,8 @@ def get_correlator_inputs(lay_time, correlator=None, connect=True):
             correlator = "FCA"
         elif correlator.lower() == "kko":
             correlator = "FCA"
+        elif correlator.lower() == 'gbo':
+            correlator = "FCG"
         elif correlator.lower() == "tone":
             # A hack to return GBO correlator inputs
             correlator = "tone"


### PR DESCRIPTION
Querying the layout db for "KKO" or "kko" should return the KKO inputs. Currently only accepting pco.

Also adds support for GBO.