### PR TITLE
feat(rfi): extend end time of two rfi bands

### DIFF
--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -53,10 +53,12 @@ BAD_FREQUENCIES = {
         [[None, None], [529.10, 536.52]],
         [[None, None], [541.60, 548.00]],
         # UHF TV Channel 27 ending CSD 3212 inclusive (2022/08/24)
-        [[None, 1661334542], [548.00, 554.49]],
+        # This is extended until CSD 3432 (2023/03/30) to account for gain errors
+        [[None, 1680204479], [548.00, 554.49]],
         [[None, None], [564.65, 578.00]],
         # UHF TV Channel 32 ending CSD 3213 inclusive (2022/08/25)
-        [[None, 1661420706], [578.00, 585.35]],
+        # This is extended until CSD 3432 (2023/03/30) to account for gain errors
+        [[None, 1680204479], [578.00, 585.35]],
         [[None, None], [693.16, 693.55]],
         [[None, None], [694.34, 696.68]],
         [[None, None], [729.88, 745.12]],


### PR DESCRIPTION
While these bands end at an earlier time, issues with gain calibration resulted in them continuing to be bad until the updated time.

Closes chime-experiment/Pipeline#125