### PR TITLE
CHIME static RFI adjustments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install black
       run: pip install black
@@ -71,10 +71,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin libhdf5-serial-dev
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install apt dependencies
         run: |

--- a/ch_util/__init__.py
+++ b/ch_util/__init__.py
@@ -25,6 +25,7 @@ Submodules
     timing
     tools
 """
+
 from . import _version
 
 __version__ = _version.get_versions()["version"]

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2421,9 +2421,7 @@ def interpolate_gain(freq, gain, weight, flag=None, length_scale=30.0):
             # of length 2 for sklearn version 1.1.2, but will have a single dimension
             # for earlier versions.  The line below ensures consistent behavior.
             if err_ypred.ndim > 1:
-                err_ypred = np.sqrt(
-                    np.sum(err_ypred**2, axis=-1) / err_ypred.shape[-1]
-                )
+                err_ypred = np.sqrt(np.sum(err_ypred**2, axis=-1) / err_ypred.shape[-1])
 
             interp_weight[test, ii] = tools.invert_no_zero(err_ypred**2)
 

--- a/ch_util/chan_monitor.py
+++ b/ch_util/chan_monitor.py
@@ -587,9 +587,11 @@ class FeedLocator(object):
             devmins = devs.min(axis=1)
             centres = np.array(
                 [
-                    xmeds[ii]  # return median
-                    if devmins[ii] < tol  # if reasonable
-                    else cylseps[np.argmin(devs[ii])]  # or use closest value
+                    (
+                        xmeds[ii]  # return median
+                        if devmins[ii] < tol  # if reasonable
+                        else cylseps[np.argmin(devs[ii])]
+                    )  # or use closest value
                     for ii in range(devmins.size)
                 ]
             )
@@ -767,11 +769,13 @@ class ChanMonitor(object):
         grd_dict = {"CygA": 4, "CasA": 4, "TauA": 3, "VirA": 1}
         # Grades for each source
         grds = [
-            grd_dict[src.name] - 2
-            if (
-                (src.name in ["CygA", "CasA"]) and (not ntt[ii])
-            )  # CasA and CygA at daytime worse than TauA at night
-            else grd_dict[src.name]
+            (
+                grd_dict[src.name] - 2
+                if (
+                    (src.name in ["CygA", "CasA"]) and (not ntt[ii])
+                )  # CasA and CygA at daytime worse than TauA at night
+                else grd_dict[src.name]
+            )
             for ii, src in enumerate(srcs)
         ]
 

--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -53,11 +53,15 @@ BAD_FREQUENCIES = {
         [[None, None], [529.10, 536.52]],
         [[None, None], [541.60, 548.00]],
         ### Additional bad bands
+        # Narrow, high power bands visible in sensitivities and
+        # some longer baselines. There is some sporadic rfi in between
+        # the two bands
+        [[None, None], [460.15, 460.55]],
+        [[None, None], [464.00, 470.32]],
         # 6 MHz band (reported by Simon)
         [[None, None], [505.85, 511.71]],
-        # This is a bright band which has been around since the beginning.
-        # It usually gets masked, but not always
-        [[None, None], [517.97, 524.60]],
+        # Bright band which has been present since early on
+        [[None, None], [517.97, 525.00]],
         # UHF TV Channel 27 ending CSD 3212 inclusive (2022/08/24)
         # This is extended until CSD 3446 (2023/04/13) to account for gain errors
         [[None, 1681410777], [548.00, 554.49]],
@@ -69,6 +73,8 @@ BAD_FREQUENCIES = {
         [[1633758888, None], [584.00, 590.00]],
         # UHF TV Channel 35
         [[1633758888, None], [596.00, 602.00]],
+        # Low power band visible in long baselines
+        [[None, None], [602.00, 607.82]],
         # from CSD 2243 (2019/12/31 - ) Rogers’ new 600 MHz band
         [[1577755022, None], [617.00, 627.00]],
         [[None, None], [693.16, 693.55]],

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -1270,10 +1270,7 @@ def get_default_frequency_map_stream() -> Tuple[np.ndarray]:
     stream[:, 3] = np.tile(np.arange(8).repeat(32), 4)
 
     stream_id = (
-        stream[:, 0] * 2**12
-        + stream[:, 1] * 2**12
-        + stream[:, 2] * 2**4
-        + stream[:, 3]
+        stream[:, 0] * 2**12 + stream[:, 1] * 2**12 + stream[:, 2] * 2**4 + stream[:, 3]
     ).astype(np.int64)
 
     return stream, stream_id

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,7 +76,9 @@ numpydoc_show_class_members = False
 
 autodoc_mock_imports = ["networkx"]
 
-intersphinx_mapping = {"https://networkx.github.io/documentation/latest/": None}
+intersphinx_mapping = {
+    "networkx": ("https://networkx.github.io/documentation/latest/", None)
+}
 # TODO: add "chimedb.core": ("http://todo/", None)}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx >= 4.0, < 5.0
+Sphinx 
 numpydoc
 sphinx_rtd_theme
 sphinxcontrib-katex

--- a/scripts/singleuse/generate_archive_test_data_2_X.py
+++ b/scripts/singleuse/generate_archive_test_data_2_X.py
@@ -4,7 +4,6 @@ Data is written to the current directory.
 
 """
 
-
 from os import path
 
 import numpy as np

--- a/scripts/singleuse/generate_archive_test_data_3_X.py
+++ b/scripts/singleuse/generate_archive_test_data_3_X.py
@@ -4,7 +4,6 @@ Data is written to the current directory.
 
 """
 
-
 from os import path
 
 import numpy as np

--- a/scripts/update_psrcat.py
+++ b/scripts/update_psrcat.py
@@ -1,6 +1,7 @@
 """Query the database for pulsar holography sources and compile them into a
 FluxCatalog-style JSON file based on the ATNF pulsar catalog.
 """
+
 import os
 
 import numpy as np

--- a/tests/data_paths.py
+++ b/tests/data_paths.py
@@ -1,6 +1,5 @@
 """Module contains paths to test data."""
 
-
 import glob
 from os import path
 

--- a/tests/test_andata_archive2.py
+++ b/tests/test_andata_archive2.py
@@ -1,6 +1,5 @@
 """Unit tests for analysis data format."""
 
-
 import unittest
 
 import numpy as np

--- a/tests/test_andata_dist.py
+++ b/tests/test_andata_dist.py
@@ -2,7 +2,6 @@
 
 """
 
-
 import unittest
 
 import numpy as np

--- a/tests/test_ephemeris.py
+++ b/tests/test_ephemeris.py
@@ -1,6 +1,5 @@
 """Unit tests for ephemeris module."""
 
-
 import os
 from datetime import datetime
 


### PR DESCRIPTION
## RFI static mask updates
1. Add some extra narrow bands which were previously being masked elsewhere
2. Extend an existing band to properly mask the edge

## Sphinx
1. Update deprecated `intersphinx mapping` syntax 
2. Use python 3.11 for sphinx
3. Remove sphinx version pin

## CI
1. Bump CI linting and docs from python 3.10 to 3.11

Also, there's a black update.