### PR TITLE
feat(tools): add function to convert beam index

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -2481,9 +2481,20 @@ def delay(
 def beam_index2number(beam_index):
     """Convert beam "index" (0-1023) to beam "number" (0-255, 1000-1255, etc.)
 
-    The latter, with 1000s indicating the beam's East-West index and the remainder
-    going from 0 through 255 indicating the beam's North-South index, is used in
-    the CHIME/FRB beam_model package."""
+    The beam "number", with 1000s indicating the beam's East-West index and the
+    remainder going from 0 through 255 indicating the beam's North-South index,
+    is used in the CHIME/FRB beam_model package.
+
+    Parameters
+    ----------
+    beam_index : int or np.ndarray of int
+        The beam index or indices to be converted.
+
+    Returns
+    -------
+    beam_number : same as beam_index
+        The corresponding beam number or numbers.
+    """
     beam_ew_index = beam_index // 256
     beam_ns_index = beam_index % 256
     beam_number = 1000 * beam_ew_index + beam_ns_index

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -2478,6 +2478,18 @@ def delay(
     return delays
 
 
+def beam_index2number(beam_index):
+    """Convert beam "index" (0-1023) to beam "number" (0-255, 1000-1255, etc.)
+
+    The latter, with 1000s indicating the beam's East-West index and the remainder
+    going from 0 through 255 indicating the beam's North-South index, is used in
+    the CHIME/FRB beam_model package."""
+    beam_ew_index = beam_index // 256
+    beam_ns_index = beam_index % 256
+    beam_number = 1000 * beam_ew_index + beam_ns_index
+    return beam_number
+
+
 def invert_no_zero(*args, **kwargs):
     from caput import tools
     import warnings


### PR DESCRIPTION
A convenience function to convert from beam indices going from 0 through 1023 to the ones used in the CHIME/FRB `beam_model` package (and other places?) that are of the form 0-255, 1000-1255, etc.