### PR TITLE
feat(hfbcat): ignore warnings re duplicate sources

### DIFF
--- a/ch_util/hfbcat.py
+++ b/ch_util/hfbcat.py
@@ -3,6 +3,7 @@ Catalog of HFB test targets
 """
 
 import os
+import warnings
 
 from .fluxcat import FluxCatalog
 
@@ -80,4 +81,8 @@ class HFBCatalog(FluxCatalog):
 
 
 # Load the HFB target list
-HFBCatalog.load(HFB_COLLECTION)
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore", r"The alternate name .* is already held by the source .*."
+    )
+    HFBCatalog.load(HFB_COLLECTION)


### PR DESCRIPTION
Suppresses these warnings each time you load the HFB catalog:
```
UserWarning: The alternate name 2E_1901 is already held by the source 3C_190.
```