### PR TITLE
Update minimum supported python to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         pip install numpy
         pip install cython
         pip install h5py
-        pip install --use-deprecated=legacy-resolver -e .
+        pip install --use-deprecated=legacy-resolver -e . --no-binary bitshuffle
         pip install pytest
 
     - name: Run tests
@@ -83,7 +83,7 @@ jobs:
         pip install numpy
         pip install cython
         pip install h5py
-        pip install --use-deprecated=legacy-resolver -e .
+        pip install --use-deprecated=legacy-resolver -e . --no-binary bitshuffle
         pip install -r doc/requirements.txt
 
     - name: Build sphinx docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.11]
+        python-version: [3.9, 3.11]
 
     runs-on: ubuntu-latest
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chimedb.data_index @ git+https://github.com/chime-experiment/chimedb_di.git
 chimedb.dataflag @ git+https://github.com/chime-experiment/chimedb_dataflag.git
 chimedb.dataset @ git+https://github.com/chime-experiment/chimedb_dataset.git
 matplotlib
-numpy >= 1.16
+numpy >= 1.16,<2
 scipy
 networkx >= 2.0
 h5py

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requires,
     extras_require={
         "chimedb_config": [


### PR DESCRIPTION
Python 3.8 is reaching end-of-life in October. I think we're OK to update this one, but we should be careful with deploying since some machines might be running python <= 3.8