### PR TITLE
fix(tools): Provide public `ensure_list` function

### DIFF
--- a/ch_util/fluxcat.py
+++ b/ch_util/fluxcat.py
@@ -23,6 +23,7 @@ import time
 
 from caput import misc
 from . import ephemeris
+from .tools import ensure_list
 
 # Define nominal frequency. Sources in catalog are ordered according to
 # their predicted flux density at this frequency. Also acts as default
@@ -398,7 +399,7 @@ class FluxCatalog(object, metaclass=MetaFluxCatalog):
             self.dec = dec
 
             self.alternate_names = [
-                format_source_name(aname) for aname in _ensure_list(alternate_names)
+                format_source_name(aname) for aname in ensure_list(alternate_names)
             ]
 
             # Measurements:
@@ -485,15 +486,15 @@ class FluxCatalog(object, metaclass=MetaFluxCatalog):
 
         # Ensure that all of the inputs are lists
         # of the same length as flux
-        flux = _ensure_list(flux)
+        flux = ensure_list(flux)
         nmeas = len(flux)
 
-        freq = _ensure_list(freq, nmeas)
-        eflux = _ensure_list(eflux, nmeas)
-        flag = _ensure_list(flag, nmeas)
-        catalog = _ensure_list(catalog, nmeas)
-        epoch = _ensure_list(epoch, nmeas)
-        citation = _ensure_list(citation, nmeas)
+        freq = ensure_list(freq, nmeas)
+        eflux = ensure_list(eflux, nmeas)
+        flag = ensure_list(flag, nmeas)
+        catalog = ensure_list(catalog, nmeas)
+        epoch = ensure_list(epoch, nmeas)
+        citation = ensure_list(citation, nmeas)
 
         # Store as list
         meas = [
@@ -1423,20 +1424,6 @@ def _print_collection_summary(collection_name, source_names, verbose=True):
 
         # Space
         print("")
-
-
-def _ensure_list(obj, num=None):
-    if hasattr(obj, "__iter__") and not isinstance(obj, str):
-        nnum = len(obj)
-        if (num is not None) and (nnum != num):
-            raise ValueError("Input list has wrong size.")
-    else:
-        if num is not None:
-            obj = [obj] * num
-        else:
-            obj = [obj]
-
-    return obj
 
 
 # Load the default collections

--- a/ch_util/hfbcat.py
+++ b/ch_util/hfbcat.py
@@ -8,7 +8,8 @@ import numpy as np
 from typing import TYPE_CHECKING, Union
 
 from . import ephemeris
-from .fluxcat import FluxCatalog, _ensure_list
+from .fluxcat import FluxCatalog
+from .tools import ensure_list
 
 if TYPE_CHECKING:
     import skyfield.starlib.Star
@@ -155,7 +156,7 @@ def get_doppler_shifted_freq(
             freq_rest = HFBCatalog[source.names].freq_abs
 
     # Prepare rest frequencies for broadcasting
-    freq_rest = np.asarray(_ensure_list(freq_rest))[:, np.newaxis]
+    freq_rest = np.asarray(ensure_list(freq_rest))[:, np.newaxis]
 
     # Get rate at which the distance between the observer and source changes
     # (positive for observer and source moving appart)

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -119,6 +119,7 @@ Miscellaneous
 =============
 
 - :py:meth:`invert_no_zero`
+- :py:meth:`ensure_list`
 """
 
 import datetime
@@ -2510,3 +2511,45 @@ def invert_no_zero(*args, **kwargs):
         category=DeprecationWarning,
     )
     return tools.invert_no_zero(*args, **kwargs)
+
+
+def ensure_list(obj, num=None):
+    """Ensure `obj` is list-like, optionally with the length `num`.
+
+    If `obj` not a string but is iterable, it is returned as-is,
+    although a length different than `num`, if given, will result in a
+    `ValueError`.
+
+    If `obj` is a string or non-iterable, a new list is created with
+    `num` copies of `obj` as elements.  In this case, if `num` is not
+    given, it is taken to be 1.
+
+    Parameters
+    ----------
+    obj
+        The object to check.
+    num: int, optional
+        If given, also ensure that the list has `num` elements.
+
+
+    Returns
+    -------
+    obj
+        The input object, or the newly created list
+
+    Raises
+    ------
+    ValueError:
+        `obj` was iterable but did not have a length of `num`
+    """
+    if hasattr(obj, "__iter__") and not isinstance(obj, str):
+        nnum = len(obj)
+        if (num is not None) and (nnum != num):
+            raise ValueError("Input list has wrong size.")
+    else:
+        if num is not None:
+            obj = [obj] * num
+        else:
+            obj = [obj]
+
+    return obj


### PR DESCRIPTION
The private function `fluxcat._ensure_list` has escaped, so let's make a public version of this very generic thing in `tools`.

It's sets a bad precedent to be importing private functions.