### PR TITLE
fix(ch_util): Import objects directly from caput.time

### DIFF
--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -10,14 +10,10 @@ import numpy as np
 import h5py
 from bitshuffle import h5
 
-tmp = h5  # To appease linters who complain about unused imports.
+from caput import memh5, tod
+import caput.time as ctime
 
-# If the `caput` package is available, get `memh5` from there.  Otherwise, use
-# the version of memh5 that ships with `ch_util`, eliminating the dependency.
-try:
-    from caput import memh5, tod
-except ImportError:
-    raise ImportError("Could not import memh5 or tod. Have you installed caput?")
+tmp = h5  # To appease linters who complain about unused imports.
 
 
 ni_msg = "Ask Kiyo to implement this."
@@ -326,12 +322,7 @@ class BaseData(tod.TOData):
 
     @staticmethod
     def convert_time(time):
-        try:
-            from .ephemeris import ensure_unix
-        except ValueError:
-            from .ephemeris import ensure_unix
-
-        return ensure_unix(time)
+        return ctime.ensure_unix(time)
 
 
 class CorrData(BaseData):
@@ -1222,8 +1213,6 @@ class HKPData(memh5.MemDiskGroup):
         -------
         data : HKPData
         """
-
-        from caput import time as ctime
 
         metrics = metrics if metrics is not None else datasets
 

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -2682,7 +2682,7 @@ def get_reference_times_dataset_id(
         logger = logging.getLogger(__name__)
 
     # Dataset IDs before this date are untrustworthy
-    ds_start = ephemeris.datetime_to_unix(datetime(2020, 11, 1))
+    ds_start = ctime.datetime_to_unix(datetime(2020, 11, 1))
     if (times < ds_start).any():
         raise ValueError(
             "Dataset IDs before 2020/11/01 are corrupt, so this method won't work. "

--- a/ch_util/chan_monitor.py
+++ b/ch_util/chan_monitor.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 import copy
+
+import caput.time as ctime
+
 from chimedb import data_index
 from ch_util import ephemeris, finder
 
@@ -14,7 +17,7 @@ R = np.array(
 )  # Cylinder rotation matrix
 C = 2.9979e8
 PHI = ephemeris.CHIMELATITUDE * np.pi / 180.0  # DRAO Latitue
-SD = 24.0 * 3600.0 * ephemeris.SIDEREAL_S  # Sidereal day
+SD = 24.0 * 3600.0 * ctime.SIDEREAL_S  # Sidereal day
 
 _DEFAULT_NODE_SPOOF = {"scinet_online": "/scratch/k/krs/jrs65/chime/archive/online/"}
 # _DEFAULT_NODE_SPOOF = {'gong': '/mnt/gong/archive'} # For tests on Marimba
@@ -739,7 +742,7 @@ class ChanMonitor(object):
         bsep2=218,
     ):
         """Initialize class from date"""
-        t1 = ephemeris.datetime_to_unix(date)
+        t1 = ctime.datetime_to_unix(date)
         return cls(
             t1,
             freq_sel=freq_sel,
@@ -933,7 +936,7 @@ class ChanMonitor(object):
         from ch_util import tools
 
         # Get CHIME ON channels:
-        half_time = ephemeris.unix_to_datetime(tms[int(len(tms) // 2)])
+        half_time = ctime.unix_to_datetime(tms[int(len(tms) // 2)])
         corr_inputs = tools.get_correlator_inputs(half_time)
         self.corr_inputs = tools.reorder_correlator_inputs(input_map, corr_inputs)
         pwds = tools.is_chime_on(self.corr_inputs)  # Which inputs are CHIME ON antennas
@@ -954,7 +957,7 @@ class ChanMonitor(object):
 
         input_map = data.input
         tms = data.time
-        half_time = ephemeris.unix_to_datetime(tms[int(len(tms) // 2)])
+        half_time = ctime.unix_to_datetime(tms[int(len(tms) // 2)])
         corr_inputs = tools.get_correlator_inputs(half_time)
         corr_inputs = tools.reorder_correlator_inputs(input_map, corr_inputs)
         pwds = tools.is_chime_on(corr_inputs)  # Which inputs are CHIME ON antennas
@@ -1099,8 +1102,8 @@ class ChanMonitor(object):
         self.night_acq_list = f_night.get_results()
 
         # Create a list of acquisitions that flag out sunrise, sun transit, and sunset
-        mm = ephemeris.unix_to_datetime(self.t1).month
-        dd = ephemeris.unix_to_datetime(self.t1).day
+        mm = ctime.unix_to_datetime(self.t1).month
+        dd = ctime.unix_to_datetime(self.t1).day
         mm = mm + float(dd) / 30.0
 
         fct = 3.0

--- a/ch_util/data_quality.py
+++ b/ch_util/data_quality.py
@@ -16,6 +16,8 @@ Auxiliary functions are still lacking documentation.
 
 import numpy as np
 
+import caput.time as ctime
+
 import ch_util.ephemeris as ch_eph
 from ch_util import andata
 from ch_util import tools
@@ -364,7 +366,7 @@ def _cut_non_chime(data, visi, chan_array, inputs=None):
     input_map = data.input
     tmstp = data.index_map["time"]["ctime"]  # time stamp
     # Datetime halfway through data:
-    half_time = ch_eph.unix_to_datetime(tmstp[int(len(tmstp) // 2)])
+    half_time = ctime.unix_to_datetime(tmstp[int(len(tmstp) // 2)])
     # Get information on correlator inputs, if not already supplied
     if inputs is None:
         inputs = tools.get_correlator_inputs(half_time)
@@ -899,7 +901,7 @@ def _create_plot(
 
     # For title, use start time stamp:
     title = "Good channels result for {0}".format(
-        ch_eph.unix_to_datetime(tmstp1[0]).date()
+        ctime.unix_to_datetime(tmstp1[0]).date()
     )
 
     # I need to know the slot for each channel:
@@ -985,14 +987,14 @@ def _create_plot(
                 if time_unit == "days":
                     plt.xlabel(
                         "Time (days since {0} UTC)".format(
-                            ch_eph.unix_to_datetime(tmstp1[0])
+                            ctime.unix_to_datetime(tmstp1[0])
                         ),
                         fontsize=10,
                     )
                 else:
                     plt.xlabel(
                         "Time (hours since {0} UTC)".format(
-                            ch_eph.unix_to_datetime(tmstp1[0])
+                            ctime.unix_to_datetime(tmstp1[0])
                         ),
                         fontsize=10,
                     )

--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -46,6 +46,8 @@ import socket
 import peewee as pw
 import re
 
+import caput.time as ctime
+
 import chimedb.core as db
 import chimedb.data_index as di
 from . import layout, ephemeris
@@ -664,8 +666,8 @@ class Finder(object):
             start_time = 0
         if end_time is None:
             end_time = time.time()
-        start_time = ephemeris.ensure_unix(start_time)
-        end_time = ephemeris.ensure_unix(end_time)
+        start_time = ctime.ensure_unix(start_time)
+        end_time = ctime.ensure_unix(end_time)
         old_start_time, old_end_time = self.time_range
         start_time = max(start_time, old_start_time)
         end_time = min(end_time, old_end_time)
@@ -733,8 +735,8 @@ class Finder(object):
             start_time = 0
         if end_time is None:
             end_time = time.time()
-        start_time = ephemeris.ensure_unix(start_time)
-        end_time = ephemeris.ensure_unix(end_time)
+        start_time = ctime.ensure_unix(start_time)
+        end_time = ctime.ensure_unix(end_time)
         range_start, range_end = self.time_range
         start_time = max(start_time, range_start)
         end_time = min(end_time, range_end)
@@ -915,11 +917,9 @@ class Finder(object):
         Total 242094.394565 seconds of data.
         """
 
-        from . import ephemeris
-
         delta_RA = (end_RA - start_RA) % 360
         mid_RA = (start_RA + delta_RA / 2.0) % 360
-        time_delta = delta_RA * 4 * 60.0 * ephemeris.SIDEREAL_S
+        time_delta = delta_RA * 4 * 60.0 * ctime.SIDEREAL_S
         self.include_transits(mid_RA, time_delta=time_delta)
 
     def exclude_RA_interval(self, start_RA, end_RA):
@@ -938,11 +938,10 @@ class Finder(object):
         Look under include_RA_interval for very similar example.
 
         """
-        from . import ephemeris
 
         delta_RA = (end_RA - start_RA) % 360
         mid_RA = (start_RA + delta_RA / 2.0) % 360
-        time_delta = delta_RA * 4 * 60.0 * ephemeris.SIDEREAL_S
+        time_delta = delta_RA * 4 * 60.0 * ctime.SIDEREAL_S
         self.exclude_transits(mid_RA, time_delta=time_delta)
 
     def include_transits(self, body, time_delta=None):
@@ -996,7 +995,7 @@ class Finder(object):
 
         Examples
         --------
-        >>> from ch_util import (finder, ephemeris)
+        >>> from ch_util import finder
         >>> from datetime import datetime
         >>> f = finder.Finder()
         >>> f.only_corr()
@@ -1204,8 +1203,8 @@ class Finder(object):
                     start, stop = layout.get_global_flag_times(f.id)
                     if stop is None:
                         stop = time.time()
-                    start = ephemeris.ensure_unix(start)
-                    stop = ephemeris.ensure_unix(stop)
+                    start = ctime.ensure_unix(start)
+                    stop = ctime.ensure_unix(stop)
                     flag_times.append((start, stop))
                 overlap = _check_intervals_overlap(time_intervals, flag_times)
             if mode is GF_WARN:
@@ -1246,8 +1245,8 @@ class Finder(object):
                     start, stop = f.start_time, f.finish_time
                     if stop is None:
                         stop = time.time()
-                    start = ephemeris.ensure_unix(start)
-                    stop = ephemeris.ensure_unix(stop)
+                    start = ctime.ensure_unix(start)
+                    stop = ctime.ensure_unix(stop)
                     flag_times.append((start, stop))
                 overlap = _check_intervals_overlap(time_intervals, flag_times)
                 if overlap:
@@ -1326,15 +1325,13 @@ class Finder(object):
 
         """
 
-        from . import ephemeris
-
         print("acquisition | name | start | length (hrs) | N files")
         row_proto = "%4d  |  %-36s  |  %s  |  %7.2f  |  %4d"
         for ii, acq in enumerate(self.acqs):
             start = acq.start_time
             finish = acq.finish_time
             length = (finish - start) / 3600.0
-            start = ephemeris.unix_to_datetime(start)
+            start = ctime.unix_to_datetime(start)
             start = start.strftime("%Y-%m-%d %H:%M")
             name = acq.name
             n_files = acq.n_timed_files

--- a/ch_util/fluxcat.py
+++ b/ch_util/fluxcat.py
@@ -22,6 +22,8 @@ import datetime
 import time
 
 from caput import misc
+import caput.time as ctime
+
 from . import ephemeris
 from .tools import ensure_list
 
@@ -843,7 +845,7 @@ class FluxCatalog(object, metaclass=MetaFluxCatalog):
         """Skyfield star representation :class:`skyfield.starlib.Star`
         for the source.
         """
-        return ephemeris.skyfield_star_from_ra_dec(self.ra, self.dec, self.name)
+        return ctime.skyfield_star_from_ra_dec(self.ra, self.dec, self.name)
 
     @property
     def freq(self):

--- a/ch_util/layout.py
+++ b/ch_util/layout.py
@@ -138,6 +138,8 @@ import re
 
 import chimedb.core
 
+import caput.time as ctime
+
 _property = property  # Do this since there is a class "property" in _db_tables.
 from ._db_tables import (
     EVENT_AT,
@@ -1465,10 +1467,8 @@ def global_flags_between(start_time, end_time, severity=None):
 
     """
 
-    from . import ephemeris
-
-    start_time = ephemeris.ensure_unix(start_time)
-    end_time = ephemeris.ensure_unix(end_time)
+    start_time = ctime.ensure_unix(start_time)
+    end_time = ctime.ensure_unix(end_time)
 
     query = global_flag.select()
     if severity:
@@ -1481,15 +1481,14 @@ def global_flags_between(start_time, end_time, severity=None):
 
     # Add constraint for the start time
     query = query.join(ststamp, on=event.start).where(
-        ststamp.time < ephemeris.unix_to_datetime(end_time)
+        ststamp.time < ctime.unix_to_datetime(end_time)
     )
     # Constrain the end time (being careful to deal with open events properly)
     query = (
         query.switch(event)
         .join(etstamp, on=event.end, join_type=pw.JOIN.LEFT_OUTER)
         .where(
-            (etstamp.time > ephemeris.unix_to_datetime(start_time))
-            | event.end.is_null()
+            (etstamp.time > ctime.unix_to_datetime(start_time)) | event.end.is_null()
         )
     )
 

--- a/ch_util/plot.py
+++ b/ch_util/plot.py
@@ -6,6 +6,9 @@ import matplotlib.pyplot as plt
 import warnings
 import datetime
 import scipy.signal as sig
+
+import caput.time as ctime
+
 from . import andata
 from . import ephemeris
 
@@ -406,8 +409,8 @@ def _full_day_shape(data, tmstp, date, n_bins=8640, axis="solar", ax=None):
     n_bins = int(n_bins)
     start_time = datetime.datetime(date[0], date[1], date[2], 8, 0, 0)  # UTC-8
     end_time = start_time + datetime.timedelta(days=1)
-    unix_start = ephemeris.datetime_to_unix(start_time)
-    unix_end = ephemeris.datetime_to_unix(end_time)
+    unix_start = ctime.datetime_to_unix(start_time)
+    unix_end = ctime.datetime_to_unix(end_time)
     print("Re-binning full day data to plot")
 
     if axis == "solar":
@@ -430,8 +433,8 @@ def _full_day_shape(data, tmstp, date, n_bins=8640, axis="solar", ax=None):
         for ii in range(len(tmstp)):
             in_range = (tmstp[ii] > start_range[0]) and (tmstp[ii] < end_range[1])
             if in_range:
-                sf_time = ephemeris.unix_to_skyfield_time(tmstp[ii])
-                sun = ephemeris.skyfield_wrapper.ephemeris["sun"]
+                sf_time = ctime.unix_to_skyfield_time(tmstp[ii])
+                sun = ctime.skyfield_wrapper.ephemeris["sun"]
                 obs = ephemeris.chime.skyfield_obs().at(sf_time)
                 azim = obs.observe(sun).apparent().altaz()[1].radians
 

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -2255,8 +2255,9 @@ def fringestop_time(
         The frequencies in the array (in MHz).
     feeds : list of CorrInputs
         The feeds in the timestream.
-    src : ephem.FixedBody
-        A PyEphem object representing the source to fringestop.
+    src : skyfield source
+        skyfield.starlib.Star or skyfield.vectorlib.VectorSum or
+        skyfield.jpllib.ChebyshevPosition body representing the source.
     wterm: bool, optional
         Include elevation information in the calculation.
     bterm: bool, optional
@@ -2342,8 +2343,9 @@ def decorrelation(
         The UNIX time of each sample, or (if csd=True), the CSD of each sample.
     feeds : list of CorrInputs
         The feeds in the timestream.
-    src : ephem.FixedBody
-        A PyEphem object representing the source to fringestop.
+    src : skyfield source
+        skyfield.starlib.Star or skyfield.vectorlib.VectorSum or
+        skyfield.jpllib.ChebyshevPosition body representing the source.
     wterm: bool, optional
         Include elevation information in the calculation.
     bterm: bool, optional
@@ -2420,8 +2422,9 @@ def delay(
         The UNIX time of each sample, or (if csd=True), the CSD of each sample.
     feeds : list of CorrInputs
         The feeds in the timestream.
-    src : ephem.FixedBody
-        A PyEphem object representing the source to fringestop.
+    src : skyfield source
+        skyfield.starlib.Star or skyfield.vectorlib.VectorSum or
+        skyfield.jpllib.ChebyshevPosition body representing the source.
     wterm: bool, optional
         Include elevation information in the calculation.
     bterm: bool, optional


### PR DESCRIPTION
This changes imports of objects moved from `ch_util.ephemeris` to `caput.time` to use the `caput.time` version directly, rather than importing that same `caput` object via its import into `ephemeris`.

This is more prep-work for splitting `ch_util.ephemeris`.