### PR TITLE
feat(tools): Expose PF_SPACE constant

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -144,11 +144,10 @@ import ch_ephem.observers
 #
 # etc.
 
-# Private data
-# ============
+# Data
+# ====
 
-_26M_B = 2.14  # m
-_PF_SPACE = 22.0  # Pathfinder cylinder spacing
+PF_SPACE = 22.0  # Pathfinder cylinder spacing
 
 
 # Classes
@@ -2515,6 +2514,7 @@ def delay(
 
     # Add the b-term for baselines including the 26m Galt telescope
     if bterm:
+        _26M_B = 2.14  # m
         b_delay = _26M_B / scipy.constants.c * np.cos(src_dec)
 
         galt_feeds = get_holographic_index(feeds)


### PR DESCRIPTION
ch_pipeline uses it, so it shouldn't be private.

Also moved the private _26M_B constant into the
function using it, to prevent it leaking out of the module in the same way.