### PR TITLE
fix(cal_utils): different fix for ruff linting error

### DIFF
--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -965,6 +965,7 @@ class FitPolyLogAmpPolyPhase(FitPoly, FitAmpPhase):
         # Calculate vandermonde matrix
         A = self._vander(ha, self.poly_deg_amp)
         center = 0.0
+        coeff = None
 
         # Iterate to obtain model estimate for amplitude
         for kk in range(niter):
@@ -972,9 +973,7 @@ class FitPolyLogAmpPolyPhase(FitPoly, FitAmpPhase):
 
             if window is not None:
                 if kk > 0:
-                    raise RuntimeError("coeff is not defined")
-                    # Where is `coeff` supposed to be defined?
-                    # center = self.peak(param=coeff)
+                    center = self.peak(param=coeff)
 
                 if np.isnan(center):
                     raise RuntimeError("No peak found.")


### PR DESCRIPTION
`coeff` is defined on the first iteration and used on subsequent iteration `(kk > 0)`.  This initializes `coeff` to None to avoid a ruff lint error.