### PR TITLE
fix(hfbcat): Re-initialise class variables

### DIFF
--- a/ch_util/fluxcat.py
+++ b/ch_util/fluxcat.py
@@ -243,7 +243,7 @@ class CurvedPowerLaw(FitSpectrum):
 
 class MetaFluxCatalog(type):
     """Metaclass for FluxCatalog.  Defines magic methods
-    for the class that can act on and provice access to the
+    for the class that can act on and provide access to the
     catalog of all astronomical sources.
     """
 
@@ -444,7 +444,7 @@ class FluxCatalog(metaclass=MetaFluxCatalog):
                 if alt_name in self._alternate_name_lookup:
                     alt_source = self._alternate_name_lookup[alt_name]
                     warnings.warn(
-                        f"The alternate name {alt_name} is already "
+                        f"The alternate name {alt_name} for {self.name} is already "
                         f"held by the source {alt_source}."
                     )
                 else:

--- a/ch_util/hfbcat.py
+++ b/ch_util/hfbcat.py
@@ -39,6 +39,10 @@ class HFBCatalog(FluxCatalog):
         "freq_abs",
     ]
 
+    _entries = {}
+    _collections = {}
+    _alternate_name_lookup = {}
+
     def __init__(
         self,
         name,


### PR DESCRIPTION
Because it subclasses from FluxCatalog, HFBCatalog by default will inherit the class variables from FluxCatalog, but that's where FluxCatalog stores the catalogs it loads at import time.  (Which seems like a weird, and un-Pythonic, effect of importing a module.)

The side effect is that all the FluxCatalog catalogs end up in the HFBCatalog as well, which I suspect is not intended.  So here's a fix to re-initialise these class variables to nothing, so that the FluxCatalog catalogs don't pollute the HFBCatalog.

Now, only the catalogue(s) loaded explicitly into HFBCatalog will exist in it.