### PR TITLE
fix(tools): typo in CorrelatorInputs __repr__

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -257,7 +257,7 @@ class CorrInput:
     def __repr__(self):
         kv = self._attribute_strings()
 
-        return self.__class__.name__ + "(" + ", ".join(kv) + ")"
+        return self.__class__.__name__ + "(" + ", ".join(kv) + ")"
 
     @property
     def id(self):


### PR DESCRIPTION
It looks like this typo was introduced when making ch_util compatible with ruff (see [here](https://github.com/chime-experiment/ch_util/commit/54c02c4cc86bcff56d7e00f4b8172316fc7816a4#diff-a18048ebc99bb3f79b09f8ccbc8d593e609a423e03fdb3c8b61491cff041c1e4L252)).