### PR TITLE
Linting fixes

### DIFF
--- a/ch_util/andata.py
+++ b/ch_util/andata.py
@@ -979,7 +979,7 @@ class HKData(BaseData):
         for dummy, d in self.datasets.items():
             if d.attrs["mux_address"] == mux:
                 return d
-        raise ValueError("No dataset with mux = %d is present." % (mux))
+        raise ValueError(f"No dataset with mux = {mux} is present.")
 
     def chan(self, mux=-1):
         """Convenience access to the list of channels in a given mux.
@@ -1062,7 +1062,7 @@ class HKData(BaseData):
         try:
             idx = list(self.index_map[chan_map]).index(chan)
         except KeyError:
-            raise ValueError("No channel %d exists for mux %d." % (chan, mux))
+            raise ValueError(f"No channel {chan} exists for mux {mux}.")
 
         # Return the data.
         return ds[idx, :]
@@ -3381,8 +3381,7 @@ def _remap_crate_corr(afile, slot):
     ]
 
     # Create new list of serials
-    serial_pat = crate_serial + ("%02i%%02i" % int(slot))
-    serials = [serial_pat % ci for ci in chanlist]
+    serials = [f"{crate_serial}{slot:02}{ci:02}" for ci in chanlist]
 
     # Create a list of channel ids (taking into account that they are
     # meaningless for the old crate)
@@ -3517,9 +3516,7 @@ def _insert_gains(data, input_sel):
                 elif key in data.history["acq"]:
                     g_data = data.history["acq"][key]
                 else:
-                    warnings.warn(
-                        "Cannot find gain entry [%s] for channel %i" % (key, chan)
-                    )
+                    warnings.warn(f"Cannot find gain entry [{key}] for channel {chan}")
                     continue
 
                 # Unpack the gain values and construct the gain array

--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -209,7 +209,7 @@ class FitTransit(metaclass=ABCMeta):
         parameter_names : np.ndarray[nparam,]
             Names of the parameters.
         """
-        return np.array(["param%d" % p for p in range(self.nparam)], dtype=np.bytes_)
+        return np.array([f"param{p}" for p in range(self.nparam)], dtype=np.bytes_)
 
     @property
     def param_corr(self):
@@ -753,8 +753,8 @@ class FitPolyRealPolyImag(FitPoly, FitRealImag):
     def parameter_names(self):
         """Array of strings containing the name of the fit parameters."""
         return np.array(
-            ["%s_poly_real_coeff%d" % (self.poly_type, p) for p in range(self.nparr)]
-            + ["%s_poly_imag_coeff%d" % (self.poly_type, p) for p in range(self.npari)],
+            [f"{self.poly_type}_poly_real_coeff{p}" for p in range(self.nparr)]
+            + [f"{self.poly_type}_poly_imag_coeff{p}" for p in range(self.npari)],
             dtype=np.bytes_,
         )
 
@@ -1144,8 +1144,8 @@ class FitPolyLogAmpPolyPhase(FitPoly, FitAmpPhase):
     def parameter_names(self):
         """Array of strings containing the name of the fit parameters."""
         return np.array(
-            ["%s_poly_amp_coeff%d" % (self.poly_type, p) for p in range(self.npara)]
-            + ["%s_poly_phi_coeff%d" % (self.poly_type, p) for p in range(self.nparp)],
+            [f"{self.poly_type}_poly_amp_coeff{p}" for p in range(self.npara)]
+            + [f"{self.poly_type}_poly_phi_coeff{p}" for p in range(self.nparp)],
             dtype=np.bytes_,
         )
 
@@ -1421,7 +1421,7 @@ class FitGaussAmpPolyPhase(FitPoly, FitAmpPhase):
         """Array of strings containing the name of the fit parameters."""
         return np.array(
             ["peak_amplitude", "centroid", "fwhm"]
-            + ["%s_poly_phi_coeff%d" % (self.poly_type, p) for p in range(self.nparp)],
+            + [f"{self.poly_type}_poly_phi_coeff{p}" for p in range(self.nparp)],
             dtype=np.bytes_,
         )
 
@@ -1695,7 +1695,7 @@ def fit_point_source_map(
                 absolute_sigma=True,
             )  # , bounds=bounds)
         except ValueError as error:
-            print("index (" + ", ".join(["%d" % ii for ii in index]) + "):", error)
+            print("index (" + ", ".join([str(ii) for ii in index]) + "):", error)
             continue
 
         # Save the results

--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -43,6 +43,7 @@ from os import path
 import time
 import socket
 import peewee as pw
+import tabulate
 
 import caput.time as ctime
 
@@ -144,7 +145,7 @@ class Finder:
     >>> from datetime import datetime
     >>> f = finder.Finder()
     >>> f.only_corr()
-    >>> f.set_time_range(datetime(2014,02,24), datetime(2014,02,25))
+    >>> f.set_time_range(datetime(2014,2,24), datetime(2014,2,25))
     >>> f.print_results_summary()
     interval | acquisition | offset from start (s) | length (s) | N files
        1  |  20140219T145849Z_abbot_corr  |   378053.1  |    86400.0  |  25
@@ -1327,17 +1328,14 @@ class Finder:
     def print_results_summary(self):
         """Print a summary of the search results."""
 
-        row_proto = "%4d | %-36s | %7.f | %7.f | %4d | %6.f"
         total_data = 0.0
         total_size = 0.0
         interval_number = 0
-        titles = ("# ", " acquisition", "start (s)", "len (s) ", "files ", "MB ")
-        print("%5s|%-38s|%9s|%9s|%6s|%8s" % titles)
+        titles = ("#", "acquisition", "start (s)", "len (s)", "files", "MB")
+        rows = []
         for ii, acq in enumerate(self.acqs):
             acq_start = acq.start_time
             intervals = self.get_results_acq(ii)
-            # if len(intervals):
-            #  print intervals[0]
             for interval in intervals:
                 offset = interval[1][0] - acq_start
                 length = interval[1][1] - interval[1][0]
@@ -1366,10 +1364,11 @@ class Finder:
                 except TypeError:
                     s = 0
                 info = (interval_number, acq.name, offset, length, n_files, s)
-                print(row_proto % info)
+                rows.append(info)
                 total_data += length
                 total_size += s
                 interval_number += 1
+        tabulate.tabulate(rows, headers=titles)
         print(f"Total {total_data:6.f} seconds, {total_size:6.f} MB of data.")
 
 

--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -147,20 +147,22 @@ class Finder:
     >>> f.only_corr()
     >>> f.set_time_range(datetime(2014,2,24), datetime(2014,2,25))
     >>> f.print_results_summary()
-    interval | acquisition | offset from start (s) | length (s) | N files
-       1  |  20140219T145849Z_abbot_corr  |   378053.1  |    86400.0  |  25
-       2  |  20140224T051212Z_stone_corr  |        0.0  |    67653.9  |  19
-    Total 154053.858720 seconds of data.
+      #  acquisition                    start (s)    len (s)    files       MB
+    ---  ---------------------------  -----------  ---------  -------  -------
+      0  20140219T145849Z_abbot_corr       378053    86400         25  3166.08
+      1  20140224T051212Z_stone_corr            0    67653.9       19  2406.78
+    Total 154054 seconds,   5573 MB of data.
 
     Search for transits of a given source.
 
     >>> import ch_ephem.sources
     >>> f.include_transits(ch_ephem.sources.CasA, time_delta=3600)
     >>> f.print_results_summary()
-    interval | acquisition | offset from start (s) | length (s) | N files
-       1  |  20140219T145849Z_abbot_corr  |   452087.2  |     3600.0  |  2
-       2  |  20140224T051212Z_stone_corr  |    55288.0  |     3600.0  |  2
-    Total 7200.000000 seconds of data.
+      #  acquisition                    start (s)    len (s)    files       MB
+    ---  ---------------------------  -----------  ---------  -------  -------
+      0  20140219T145849Z_abbot_corr     452092         3600        2  253.286
+      1  20140224T051212Z_stone_corr      55292.9       3600        2  253.346
+    Total   7200 seconds,    507 MB of data.
 
     To read the data,
 
@@ -184,50 +186,45 @@ class Finder:
     ...               & (di.CorrAcqInfo.nprod == 36)
     ...               & (di.ArchiveInst.name == 'stone'))
     >>> f.print_results_summary()
-    interval | acquisition | offset from start (s) | length (s) | N files
-       1  |  20140211T020307Z_stone_corr  |        0.0  |      391.8  |  108
-       2  |  20140128T135105Z_stone_corr  |        0.0  |     4165.2  |  104
-       3  |  20131208T070336Z_stone_corr  |        0.0  |     1429.8  |  377
-       4  |  20140212T014603Z_stone_corr  |        0.0  |     2424.4  |  660
-       5  |  20131210T060233Z_stone_corr  |        0.0  |     1875.3  |  511
-       6  |  20140210T021023Z_stone_corr  |        0.0  |      874.1  |  240
-    Total 11160.663510 seconds of data.
+      #  acquisition                    start (s)    len (s)    files        MB
+    ---  ---------------------------  -----------  ---------  -------  --------
+      0  20140211T020307Z_stone_corr            0    391.764      108   13594.1
+      1  20140128T135105Z_stone_corr            0   4165.22       104  131711
+      2  20131208T070336Z_stone_corr            0   1429.78       377   47676.4
+      3  20140212T014603Z_stone_corr            0   2424.43       660   83604.1
+      4  20131210T060233Z_stone_corr            0   1875.32       511   64704.8
+      5  20140210T021023Z_stone_corr            0    874.144      240   30286.4
+    Total  11161 seconds, 371577 MB of data.
+
 
     Here is an example that uses node spoofing and also filters files within
     acquisitions to include only LNA housekeeping files:
 
-    >>> f = finder.Finder(node_spoof = {"gong" : "/mnt/gong/archive",
-                                            "suzu" : "/mnt/suzu/hk_data"})
+    >>> f = finder.Finder(node_spoof={"scinet_hpss": "/dev/null"})
     >>> f.only_hk()
     >>> f.set_time_range(datetime(2014, 9, 1), datetime(2014, 10, 10))
     >>> f.print_results_summary()
-    # | acquisition                          |start (s)| len (s) |files |     MB
-    0 | 20140830T005410Z_ben_hk              |  169549 |  419873 |   47 |   2093
-    1 | 20140905T203905Z_ben_hk              |       0 |   16969 |    2 |      0
-    2 | 20140908T153116Z_ben_hk              |       0 | 1116260 |   56 |      4
-    3 | 20141009T222415Z_ben_hk              |       0 |    5745 |    2 |      0
+      #  acquisition                start (s)           len (s)    files            MB
+    ---  -----------------------  -----------  ----------------  -------  ------------
+      0  20140830T005410Z_ben_hk       169549  419873                 47  2093
+      1  20140905T203905Z_ben_hk            0   16969.1                2     0.0832596
+      2  20140908T153116Z_ben_hk            0       1.11626e+06       56     4.45599
+      3  20141009T222415Z_ben_hk            0    5744.8                2     0.191574
+    Total 1558847 seconds,   2098 MB of data.
     >>> res = f.get_results(file_condition = (di.HKFileInfo.atmel_name == "LNA"))
     >>> for r in res:
-    ...   print("No. files: %d" % (len(r[0]))
+    ...   print(f"No. files: {len(r[0])}")
+    ...
     No. files: 8
     No. files: 1
     No. files: 19
     No. files: 1
-    >>> data = res[0].as_loaded_data()
-    >>> for m in data.mux:
-    ...   print("Mux %d: %s", (m, data.chan(m)))
-    Mux 0: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    Mux 1: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    Mux 2: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    >>> print(data.tod(14, 1))
-    [1744.190917, 1766.344726, 1771.033569, ..., 1928.612792, 1938.900756, 1945.534912]
 
     In the above example, the restriction to LNA housekeeping could also have
     been accomplished with the convenience method :meth:`Finder.set_hk_input`:
 
     >>> f.set_hk_input("LNA")
     >>> res = f.get_results()
-
     """
 
     # Constructors and setup
@@ -1368,8 +1365,8 @@ class Finder:
                 total_data += length
                 total_size += s
                 interval_number += 1
-        tabulate.tabulate(rows, headers=titles)
-        print(f"Total {total_data:6.f} seconds, {total_size:6.f} MB of data.")
+        print(tabulate.tabulate(rows, headers=titles))
+        print(f"Total {total_data:6.0f} seconds, {total_size:6.0f} MB of data.")
 
 
 def _trim_intervals_range(intervals, time_range, min_interval=0.0):

--- a/ch_util/fluxcat.py
+++ b/ch_util/fluxcat.py
@@ -669,7 +669,9 @@ class FluxCatalog(metaclass=MetaFluxCatalog):
 
         # Create block with statistics
         if not residuals:
-            txt = r"$\chi^2 = %0.2f$ $(%d)$" % (self.stats["chisq"], self.stats["ndof"])
+            txt = (
+                r"$\chi^2" + f' = {self.stats["chisq"]:0.2f}$ $({self.stats["ndof"]})$'
+            )
 
             plt.text(
                 0.95,
@@ -1475,7 +1477,7 @@ def _print_collection_summary(collection_name, source_names, verbose=True):
     nsrc = len(source_names)
 
     # Create a header containing the collection name and number of sources
-    header = collection_name + "  (%d Sources)" % nsrc
+    header = collection_name + f"  ({nsrc} Sources)"
     print(header)
 
     # Print the sources contained in this collection

--- a/ch_util/ni_utils.py
+++ b/ch_util/ni_utils.py
@@ -92,7 +92,8 @@ def process_synced_data(data, ni_params=None, only_off=False):
             t_str = t.strftime("%Y %b %d %H:%M:%S UTC")
             err_str = (
                 "ni_params parameter is required for data before "
-                "%s (ctime=%i)." % (t_str, ctime_no_noise_inj_data)
+                + t_str
+                + f" (ctime={ctime_no_noise_inj_data})."
             )
             raise Exception(err_str)
 

--- a/ch_util/rfi.py
+++ b/ch_util/rfi.py
@@ -355,10 +355,8 @@ def get_autocorrelations(
 
         if not partial_stack and hasattr(data, "input_flags"):
             input_flags = data.input_flags[:]
-            logger.info(
-                "There are on average %d good inputs."
-                % np.mean(np.sum(input_flags, axis=0), axis=-1)
-            )
+            good_inputs = np.mean(np.sum(input_flags, axis=0), axis=-1)
+            logger.info(f"There are on average {good_inputs} good inputs.")
 
             if np.any(input_flags) and not np.all(input_flags):
                 logger.info("Applying input_flags to weight.")

--- a/ch_util/timing.py
+++ b/ch_util/timing.py
@@ -690,8 +690,8 @@ class TimingCorrection(andata.BaseData):
                 tau_init = tau_init[:, np.newaxis]
             else:
                 raise ValueError(
-                    "Initial tau has size %d, but there are %d noise sources."
-                    % (tau_init.size, tau_ref.shape[0])
+                    f"Initial tau has size {tau_init.size}, "
+                    f"but there are {tau_ref.shape[0]} noise sources."
                 )
 
         if alpha_init is None:
@@ -701,8 +701,8 @@ class TimingCorrection(andata.BaseData):
                 alpha_init = alpha_init[:, np.newaxis]
             else:
                 raise ValueError(
-                    "Initial alpha has size %d, but there are %d noise sources."
-                    % (alpha_init.size, alpha_ref.shape[0])
+                    f"Initial alpha has size {alpha_init.size}, "
+                    f"but there are {alpha_ref.shape[0]} noise sources."
                 )
 
         tau_ref = np.concatenate((tau_init, tau_ref), axis=-1)
@@ -2115,7 +2115,7 @@ def construct_delay_template(
         nsource = amp.local_shape[1]
         ilocal = range(amp.local_offset[1], amp.local_offset[1] + nsource)
 
-        logger.info("I am processing %d noise source inputs." % nsource)
+        logger.info("I am processing {nsource} noise source inputs.")
 
         amp = amp[:].view(np.ndarray)
         phi = phi[:].view(np.ndarray)
@@ -2178,7 +2178,7 @@ def construct_delay_template(
 
     # Estimate variance of each frequency from residuals
     for iter_weight in range(max_iter_weight):
-        msg = ["Iteration %d of %d" % (iter_weight + 1, max_iter_weight)]
+        msg = [f"Iteration {iter_weight + 1} of {max_iter_weight}"]
 
         dphi = _correct_phase_wrap(phi - static_phi[:, :, np.newaxis])
         damp = amp - static_amp[:, :, np.newaxis]
@@ -2447,8 +2447,8 @@ def fit_poly_to_phase(freq, resp, resp_error, nparam=2):
 
     if flg.size < (nparam + 1):
         msg = (
-            "Number of data points must be greater than number of parameters (%d)."
-            % nparam
+            "Number of data points must be greater than number of parameters "
+            + f"({nparam})."
         )
         raise RuntimeError(msg)
 

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -198,9 +198,9 @@ class HKInput:
         self.mux = mux
 
     def __repr__(self):
-        ret = "<HKInput atmel=%s chan=%d " % (self.atmel.sn, self.chan)
+        ret = f"<HKInput atmel={self.atmel.sn} chan={self.chan} "
         if self.mux:
-            ret += "mux=%d>" % self.mux
+            ret += f"mux={self.mux}>"
         else:
             ret += "(no mux)>"
         return ret
@@ -1046,7 +1046,7 @@ def hk_to_sensor(graph, inp):
                 )
 
             # Construct the S/N of the mux connector and get it.
-            sn = "%s%d%s" % (thing.sn, inp.mux, "A" if inp.chan < 8 else "B")
+            sn = thing.sn + str(inp.mux) + ("A" if inp.chan < 8 else "B")
             try:
                 mux_card = graph.component(comp=sn)
             except layout.NotFound:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "numpy >= 1.24",
     "peewee >= 3.14.1",
     "scipy",
-    "skyfield >= 1.10"
+    "skyfield >= 1.10",
+    "tabulate"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_andata_dist.py
+++ b/tests/test_andata_dist.py
@@ -1,6 +1,4 @@
-"""Tests of the distributed features of AnData.
-
-"""
+"""Tests of the distributed features of AnData."""
 
 import unittest
 


### PR DESCRIPTION
This updates the code for changes to `black` and `ruff`.  It's almost entirely getting rid of the old `"%s%d" % (var1, var2)"` formatting style.

However, to simplify things, I've introduced a `tabulate` dependency to take care of rendering the results table in `finder`, instead of the Finder doing the tabulation manually.

And, just to make sure I hadn't introduced a bug, I went through the worked example in the docstring and updated it for the `tabulate`-generated tables.