### PR TITLE
feat(alpenhorn_holography): Moved from ch_alpenhorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "chimedb.dataflag @ git+https://github.com/chime-experiment/chimedb_dataflag.git",
     "chimedb.dataset @ git+https://github.com/chime-experiment/chimedb_dataset.git",
     "bitshuffle",
+    "click",
     "h5py",
     "matplotlib",
     "mpi4py",
@@ -45,6 +46,9 @@ doc = [
 test = [
   "pytest >= 7.0"
 ]
+
+[project.scripts]
+alpenhorn_holography = "ch_util.holography_cli:cli"
 
 [tool.ruff]
 lint.select = ["E", "F", "UP", "NPY", "BLE", "C4", "RET"]


### PR DESCRIPTION
This is a transfer of the "alpenhorn_holography" script that used to be in `ch_alpenhorn`.

Despite the name, this script is unrelated to alpenhorn.  I need to move it out of `ch_alpenhorn` so that repo can be retooled for alpenhorn-2.

Note: though I've renamed the module itself to `ch_util.holography_cli`, the installed script is still called `alpenhorn_holography` to avoid making breaking changes.

I've done some light editing to the script for the deprecation of `ch_util.ephemeris` and to get the code to conform to the required linting standard in this repository.

I guess this finally takes care of this ancient thing: https://github.com/chime-experiment/ch_alpenhorn/issues/1