### PR TITLE
Fix radiocosmology imports

### DIFF
--- a/ch_util/ephemeris.py
+++ b/ch_util/ephemeris.py
@@ -8,7 +8,7 @@ For instrument-independent stuff, use `caput`.
 
 import warnings
 
-from caput.interferometry import sphdist as sphdist
+from caput.coordinates.spherical import sphdist as sphdist
 from caput.time import (
     unix_to_datetime as unix_to_datetime,
     datetime_to_unix as datetime_to_unix,

--- a/ch_util/holography.py
+++ b/ch_util/holography.py
@@ -262,7 +262,7 @@ class HolographyObservation(base_model):
         none
         """
 
-        from caput.interferometry import sphdist
+        from caput.coordinates.spherical import sphdist
         from skyfield.positionlib import Angle
 
         ts = ctime.skyfield_wrapper.timescale

--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -135,10 +135,7 @@ import scipy.linalg as la
 import re
 
 from caput import pfb
-from caput.interferometry import (
-    projected_distance,
-    fringestop_phase as fringestop_phase,
-)
+from caput.coordinates.spherical import projected_distance
 
 import ch_ephem.observers
 


### PR DESCRIPTION
In radiocosmology/caput#298, I move the `interferometry` module to a combination of `cora` and `driftscan`. This PR fixes those imports.

~~Importantly, this adds dependency on `cora` and `driftscan`. Most dependencies are shared, but this means that `healpy` ends up being added as a dependency here. I'm open to arguments about moving all the coordinate stuff to `caput`, so I'd like thoughts.~~ Actually, coordinates were moved to `caput`.