### PR TITLE
feat(Finder): Add HFB compression flag to finder.

### DIFF
--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -491,11 +491,21 @@ class Finder:
         self._file_info = [di.RawadcFileInfo]
         self.filter_acqs(True)
 
-    def only_hfb(self):
-        """Only include HFB acquisitions in this search."""
+    def only_hfb(self, compression=None):
+        """Only include HFB acquisitions in this search.
+
+        Parameters
+        ----------
+        compression : bool, optional
+            If True or False, only select acqs with compressed/uncompressed
+            files.  By default, this is None, and all acqs are selected.
+        """
         self._acq_info = [di.HFBAcqInfo]
         self._file_info = [di.HFBFileInfo]
-        self.filter_acqs(True)
+        if compression is True or compression is False:
+            self.filter_acqs(di.HFBFileInfo.compressed == compression)
+        else:
+            self.filter_acqs(True)
 
     def only_weather(self):
         """Only include weather acquisitions in this search."""


### PR DESCRIPTION
Note: this is an _acq_ limit which will select all acquisitions with compressed files in them.  It doesn't specifically select acqs with AcqType `hfbcomp`.  Should it?