### PR TITLE
fix(cal_utils): handle RuntimeError during fit by setting parameters to NaN

### DIFF
--- a/ch_util/cal_utils.py
+++ b/ch_util/cal_utils.py
@@ -189,7 +189,7 @@ class FitTransit(metaclass=ABCMeta):
                         absolute_sigma=absolute_sigma,
                         **kwargs,
                     )
-                except (ValueError, KeyError) as error:
+                except (ValueError, KeyError, RuntimeError) as error:
                     logger.debug(f"Index {ind!s} failed with error: {error}")
                     continue
 


### PR DESCRIPTION
If the fit fails to converge after the maximum number of function evaluations,
a RuntimeError is raised. Previously this caused the `source_spectra` analyzer
in `dias` to crash and broadcast an alert. This error is likely triggered by
RFI-contaminated frequencies. The fix prints a debug message to the log,
sets best-fit parameter values to NaN, and then continues to other frequencies
and polarisations.
