### PR TITLE
fix(tools): Rename hco cylinder for layoutDB

### DIFF
--- a/ch_util/tools.py
+++ b/ch_util/tools.py
@@ -685,12 +685,12 @@ def _get_input_props(lay, corr_input, corr, rfl_path, rfi_antenna, noise_source)
         "cylinder_D": 5,
         "pco_cylinder": 6,
         "gbo_cylinder": 7,
-        "hcro_cylinder": 8,
+        "hco_cylinder": 8,
     }
 
     cyl = pos_dict[rfl.sn]
 
-    # Different conventions for CHIME, PCO, GBO, HCRO, and Pathfinder
+    # Different conventions for CHIME, PCO, GBO, HCO, and Pathfinder
     if cyl >= 2 and cyl <= 5:
         # Dealing with a CHIME feed
 


### PR DESCRIPTION
Small fix to enable functionality of layoutDB. Database defines the cylinder as `hco_cylinder` and not `hcro_cylinder`. 