### PR TITLE
refactor(finder): Search active archive nodes by default

### DIFF
--- a/ch_util/finder.py
+++ b/ch_util/finder.py
@@ -42,7 +42,6 @@ Routines
 import logging
 from os import path
 import time
-import socket
 import peewee as pw
 import tabulate
 
@@ -235,16 +234,19 @@ class Finder:
         import copy
 
         # Which nodes do we have available?
-        host = socket.gethostname().split(".")[0]
         self._my_node = []
         self._node_spoof = node_spoof
 
         connect_database()
 
         if not node_spoof:
+            # If not given a node list, search all active archive nodes
+            logging.warning(
+                "No node_spoof provided.  Searching all active archive nodes."
+            )
             for n in (
                 di.StorageNode.select()
-                .where(di.StorageNode.host == host)
+                .where(di.StorageNode.archive)
                 .where(di.StorageNode.active)
             ):
                 self._my_node.append(n)


### PR DESCRIPTION
This changes what the `Finder` does when _not_ given a `node_spoof`.

In the past, in this case, `Finder` would look at the local hostname and try to match that against host values in the database.  This was never a good default and almost always _not_ what a user would want, since it would only be useful if running `Finder` on a machine which
also happened to be running the alpenhorn daemon.   As a result, we
almost always use `node_spoof` when running `Finder`.

This changes the default node list to not consider the local hostname, and instead just look at _all_ the currently active archive nodes.  This ensures users will find anything that matches their query, even though they may not know where the file is.

Alpenhorn per se has slowly migrated the meaning of the "host" field. Now alpenhorn's "host" field is typically a logical value (like "scinet" or "fir"), which doesn't correspond to any local hostname and the value used is set in the daemon's config file.

Requires https://github.com/chime-experiment/chimedb_di/pull/33